### PR TITLE
Fix wrong indentation caused when fixing conflict

### DIFF
--- a/plugins/spank_ibm_qrun/spank_ibm_qrun.c
+++ b/plugins/spank_ibm_qrun/spank_ibm_qrun.c
@@ -220,9 +220,9 @@ int slurm_spank_task_init(spank_t spank_ctxt, int argc, char **argv)
             spank_setenv(spank_ctxt, "IBMQRUN_PRIMITIVE", primitive_type, 1);
         }
 
- 	      if (spank_get_item(spank_ctxt, S_JOB_ID, &job_id) == ESPANK_SUCCESS) { 
- 	          if (slurm_load_job(&job_info_msg, job_id, SHOW_DETAIL) == SLURM_SUCCESS) {
- 		            /* slurm's time limit is represented in minutes */
+        if (spank_get_item(spank_ctxt, S_JOB_ID, &job_id) == ESPANK_SUCCESS) { 
+            if (slurm_load_job(&job_info_msg, job_id, SHOW_DETAIL) == SLURM_SUCCESS) {
+                /* slurm's time limit is represented in minutes */
                 uint32_t time_limit_mins = job_info_msg->job_array[0].time_limit;
                 /*
                  * minutes to seconds, uint32_t to char*
@@ -232,7 +232,7 @@ int slurm_spank_task_init(spank_t spank_ctxt, int argc, char **argv)
                 snprintf(limit_as_str, sizeof(limit_as_str), "%u", time_limit_mins * 60);
                 spank_setenv(spank_ctxt, "IBMQRUN_TIMEOUT_SECONDS", limit_as_str, 1);
             }
-  	    }
+  	}
     }
 
     slurm_debug("%s: <- %s rc=%d", plugin_name, __FUNCTION__, rc);


### PR DESCRIPTION
Fixed wrong indentation caused by [this](https://github.com/qiskit-community/spank-plugins/pull/20/commits/e2503e9f7be940a8de2abdbbe3666155f9a3d265).