### PR TITLE
Use slurm-24-11-2-1 as base / Describe how to setup S3 bucket by CLI in INSTALL.md

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -69,11 +69,57 @@ docker compose up -d
 
 #### 8. Creating a S3 bucket for testing
 
-- Open http://localhost:9001 with your browser
+S3 Bucket creation can be done via a)Web Browser or b)CLI.
+
+a) Using MinIO Object Browser
+- Open http://localhost:9001 with your browser running on your Host
 - Login with minioadmin / minioadmin
 - Click 'Create a Bucket' hyperlink in Object Browser tab
 - Specify `slurm-qrun` as Bucket Name.
 - Click 'Create Bucket'
+
+
+b) Using CLI
+
+```bash
+% docker exec -it slurm-docker-cluster-minio-1 bash
+bash-5.1# mc alias set local http://localhost:9000 minioadmin minioadmin
+bash-5.1# mc alias list
+gcs
+  URL       : https://storage.googleapis.com
+  AccessKey : YOUR-ACCESS-KEY-HERE
+  SecretKey : YOUR-SECRET-KEY-HERE
+  API       : S3v2
+  Path      : dns
+  Src       : /tmp/.mc/config.json
+
+local
+  URL       : http://localhost:9000
+  AccessKey : minioadmin
+  SecretKey : minioadmin
+  API       : s3v4
+  Path      : auto
+  Src       : /tmp/.mc/config.json
+
+play
+  URL       : https://play.min.io
+  AccessKey : Q3AM3UQ867SPQQA43P2F
+  SecretKey : zuf+tfteSlswRu7BJ86wekitnifILbZam1KYY3TG
+  API       : S3v4
+  Path      : auto
+  Src       : /tmp/.mc/config.json
+
+s3
+  URL       : https://s3.amazonaws.com
+  AccessKey : YOUR-ACCESS-KEY-HERE
+  SecretKey : YOUR-SECRET-KEY-HERE
+  API       : S3v4
+  Path      : dns
+  Src       : /tmp/.mc/config.json
+
+bash-5.1# mc mb local/slurm-qrun
+bash-5.1# exit
+```
 
 #### 9. Starting Slurm Cluster
 

--- a/demo/qrun/slurm-docker-cluster/file.patch
+++ b/demo/qrun/slurm-docker-cluster/file.patch
@@ -4,12 +4,12 @@ diff -Naru slurm-docker-cluster.orig/.env slurm-docker-cluster/.env
 @@ -1,6 +1,6 @@
  # Slurm git repo tag. See https://github.com/SchedMD/slurm/tags
 -SLURM_TAG=slurm-21-08-6-1
-+SLURM_TAG=slurm-24-11-1-1
++SLURM_TAG=slurm-24-11-2-1
  
  # Image version used to tag the container at build time (Typically matches the
  # Slurm tag in semantic version form)
 -IMAGE_TAG=21.08.6
-+IMAGE_TAG=24.11.1-dev
++IMAGE_TAG=24.11.2.1-dev
 diff -Naru slurm-docker-cluster.orig/Dockerfile slurm-docker-cluster/Dockerfile
 --- slurm-docker-cluster.orig/Dockerfile	2025-03-05 20:41:41
 +++ slurm-docker-cluster/Dockerfile	2025-03-05 23:47:10


### PR DESCRIPTION
## Description of Change

<!-- Please include a readable description about the change. -->
Slurm 24-11-2-1 is now available, so this PR updates demo/qrun/slurm-docker-cluster/file.patch to use this latest Slurm version.

Also, updated INSTALL.md to describe how to set up S3 Bucket by MinIO CLI in addition to setup with browser.

Testcases:
- Verify slurm-docker-cluster is created with the latest version of Slurm, by referring to INSTALL.md.

## Checklist ✅

- [x] Have you included a description of this change?
- [x] Have you updated the relevant documentation to reflect this change?
- [ ] Have you made sure CI is passing before requesting a review?

## Ticket
- [ ] Fixes #
- [ ] Is Part of #
