### PR TITLE
Pin down reqwest version as next patch version breaks reqwest-middlware

### DIFF
--- a/commands/qrun/daapi/Cargo.toml
+++ b/commands/qrun/daapi/Cargo.toml
@@ -16,7 +16,7 @@ api_version = []
 
 [dependencies]
 anyhow = { version = "1.0.90", features = ["backtrace"] }
-reqwest = { version = "0.12.8", features = ["json"] }
+reqwest = { version = "=0.12.12", features = ["json"] }
 thiserror = "1.0.64"
 retry-policies = "0.4.0"
 chrono = "0.4.38"


### PR DESCRIPTION
The most recent reqwest version breaks reqwest-middlware.
Per the conversation in the reqwest-middlware repo it isn't clear how or when this will get fixed so I would propose to pin this also on our side as we're several people setting up this repo at the moment.

https://github.com/TrueLayer/reqwest-middleware/issues/224