### PR TITLE
QRMI: Add support of CentOS Stream 9, 10 and RHEL10

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -49,6 +49,20 @@ popd
 patch -p1 < ./shared/spank-plugins/demo/qrmi/slurm-docker-cluster/file.patch
 ```
 
+Rocky Linux 9 is used as default. If you want to another  operating system, apply additional patch.
+
+##### CentOS Stream 9
+
+```bash
+patch -p1 < ./shared/spank-plugins/demo/qrmi/slurm-docker-cluster/centos9.patch
+```
+
+##### CentOS Stream 10
+
+```bash
+patch -p1 < ./shared/spank-plugins/demo/qrmi/slurm-docker-cluster/centos10.patch
+```
+
 #### 5. Building containers
 
 ```bash

--- a/demo/qrmi/slurm-docker-cluster/centos10.patch
+++ b/demo/qrmi/slurm-docker-cluster/centos10.patch
@@ -1,0 +1,44 @@
+diff -Naru slurm-docker-cluster/.env slurm-docker-cluster.centos10/.env
+--- slurm-docker-cluster/.env	2025-05-24 01:07:36
++++ slurm-docker-cluster.centos10/.env	2025-05-24 01:20:47
+@@ -3,4 +3,4 @@
+ 
+ # Image version used to tag the container at build time (Typically matches the
+ # Slurm tag in semantic version form)
+-IMAGE_TAG=24.11.5.1-dev
++IMAGE_TAG=24.11.5.1-centos10-dev
+diff -Naru slurm-docker-cluster/Dockerfile slurm-docker-cluster.centos10/Dockerfile
+--- slurm-docker-cluster/Dockerfile	2025-05-24 01:07:39
++++ slurm-docker-cluster.centos10/Dockerfile	2025-05-24 01:20:49
+@@ -1,4 +1,4 @@
+-FROM rockylinux:9
++FROM quay.io/centos/centos:stream10
+ 
+ LABEL org.opencontainers.image.source="https://github.com/giovtorres/slurm-docker-cluster" \
+       org.opencontainers.image.title="slurm-docker-cluster" \
+@@ -29,7 +29,6 @@
+        psmisc \
+        bash-completion \
+        vim-enhanced \
+-       http-parser-devel \
+        json-c-devel \
+        cmake \
+        clang-tools-extra \
+@@ -89,8 +88,15 @@
+         /var/lib/slurmd/assoc_usage \
+         /var/lib/slurmd/qos_usage \
+         /var/lib/slurmd/fed_mgr_state \
+-    && chown -R slurm:slurm /var/*/slurm* \
+-    && /sbin/create-munge-key
++    && chown -R slurm:slurm /var/*/slurm*
++
++RUN dd if=/dev/urandom bs=1 count=1024 > /etc/munge/munge.key
++RUN chown munge: /etc/munge/munge.key
++RUN chmod 400 /etc/munge/munge.key
++RUN mkdir -p /var/run/munge
++RUN chown -R munge: /etc/munge/ /var/log/munge/ /var/lib/munge/ /run/munge/
++RUN chmod 0700 /etc/munge/ /var/log/munge/ /var/lib/munge/
++RUN chmod 755 /run/munge
+ 
+ COPY slurm.conf /etc/slurm/slurm.conf
+ COPY slurmdbd.conf /etc/slurm/slurmdbd.conf

--- a/demo/qrmi/slurm-docker-cluster/centos9.patch
+++ b/demo/qrmi/slurm-docker-cluster/centos9.patch
@@ -1,0 +1,18 @@
+diff -Naru slurm-docker-cluster/.env slurm-docker-cluster.centos9/.env
+--- slurm-docker-cluster/.env	2025-05-24 01:07:36
++++ slurm-docker-cluster.centos9/.env	2025-05-24 01:08:22
+@@ -3,4 +3,4 @@
+ 
+ # Image version used to tag the container at build time (Typically matches the
+ # Slurm tag in semantic version form)
+-IMAGE_TAG=24.11.5.1-dev
++IMAGE_TAG=24.11.5.1-centos9-dev
+diff -Naru slurm-docker-cluster/Dockerfile slurm-docker-cluster.centos9/Dockerfile
+--- slurm-docker-cluster/Dockerfile	2025-05-24 01:07:39
++++ slurm-docker-cluster.centos9/Dockerfile	2025-05-24 01:08:25
+@@ -1,4 +1,4 @@
+-FROM rockylinux:9
++FROM quay.io/centos/centos:stream9
+ 
+ LABEL org.opencontainers.image.source="https://github.com/giovtorres/slurm-docker-cluster" \
+       org.opencontainers.image.title="slurm-docker-cluster" \

--- a/qrmi/README.md
+++ b/qrmi/README.md
@@ -5,8 +5,11 @@
 * Linux
   * AlmaLinux 9
   * Amazon Linux 2023
+  * CentOS Stream 9
+  * CentOS Stream 10
   * RedHat Enterprise Linux 8
   * RedHat Enterprise Linux 9
+  * RedHat Enterprise Linux 10
   * Rocky Linux 8
   * Rocky Linux 9
   * SuSE 15

--- a/qrmi/dependencies/direct_access_client/README.md
+++ b/qrmi/dependencies/direct_access_client/README.md
@@ -15,8 +15,13 @@ This Rust API client provides all functionalities provided by Direct Access API,
 * Linux
   * AlmaLinux 9
   * Amazon Linux 2023
+  * CentOS Stream 9
+  * CentOS Stream 10
   * RedHat Enterprise Linux 8
   * RedHat Enterprise Linux 9
+  * RedHat Enterprise Linux 10
+  * Rocky Linux 8
+  * Rocky Linux 9
   * SuSE 15
   * Ubuntu 22.04
   * Ubuntu 24.04


### PR DESCRIPTION
## Description of Change

<!-- Please include a readable description about the change. -->
Added CentOS Stream 9 and 10, RedHat Enterprise Linux 10 to the supported platform list.
Also added 2 patch files to setup slurm-docker-cluster with CentOS Stream 9 and 10.

## Checklist ✅

- [ ] Have you included a description of this change?
- [ ] Have you updated the relevant documentation to reflect this change?
- [ ] Have you made sure CI is passing before requesting a review?

## Ticket
- [ ] Fixes #
- [ ] Is Part of #
