### PR TITLE
Improve error handling in plugin code

### DIFF
--- a/plugins/spank_qrmi/Cargo.toml
+++ b/plugins/spank_qrmi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spank-qrmi"
-version = "0.3.0"
+version = "0.3.1"
 edition = "2021"
 
 [lib]

--- a/plugins/spank_qrmi/src/lib.rs
+++ b/plugins/spank_qrmi/src/lib.rs
@@ -210,7 +210,12 @@ unsafe impl Plugin for SpankQrmi {
                 let token: Option<String> = match instance.acquire() {
                     Ok(v) => Some(v),
                     Err(err) => {
-                        error!("qrmi.acquire() failed: {:#?}", err);
+                        error!(
+                            "Failed to acquire quantum resource: {}/{:#?}, reason: {}",
+                            qpu_name,
+                            qrmi.r#type,
+                            err.to_string()
+                        );
                         None
                     }
                 };
@@ -269,7 +274,17 @@ unsafe impl Plugin for SpankQrmi {
                         }
                         ResourceType::PasqalCloud => Box::new(PasqalCloud::new(name)),
                     };
-                    let _ = instance.release(token);
+                    match instance.release(token) {
+                        Ok(()) => (),
+                        Err(err) => {
+                            error!(
+                                "Failed to release quantum resource: {}/{:#?}. reason = {}",
+                                name,
+                                res_type,
+                                err.to_string()
+                            );
+                        }
+                    }
                 }
             }
         }

--- a/plugins/spank_qrmi/src/lib.rs
+++ b/plugins/spank_qrmi/src/lib.rs
@@ -235,7 +235,7 @@ unsafe impl Plugin for SpankQrmi {
                 if let Some(acquisition_token) = token {
                     debug!("acquisition token = {}", acquisition_token);
                     match qrmi.r#type {
-                        // TODO: Use unified environmet variable name
+                        // TODO: Use unified environment variable name
                         ResourceType::IBMDirectAccess => {
                             spank.setenv(
                                 format!("{qpu_name}_QRMI_IBM_DA_SESSION_ID"),


### PR DESCRIPTION
## Description of Change

<!-- Please include a readable description about the change. -->
During our investigation of [this Git issue](https://github.com/qiskit-community/spank-plugins/issues/72), we found that if an incorrect `qrmi_config.json` is specified, the slurm daemon that calls the spank plugin will exit due to Rust's `panic/expect()`, resulting in an error message that is not well understood by users or administrators error message that is not well understood by users or administrators.

This PR modifies the error handling within the spank plugin to return Err.

### Current:
```
thread '<unnamed>' panicked at /root/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/slurm-spank-0.4.0/src/lib.rs:1044:14:
Failed to acquire global options mutex: "Poisoned(..)"
slurmstepd: error: Caught panic while running spank callback: Failed to acquire global options mutex: "Poisoned(..)"

thread '<unnamed>' panicked at /root/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/slurm-spank-0.4.0/src/lib.rs:1044:14:
Failed to acquire global options mutex: "Poisoned(..)"
slurmstepd: error: Caught panic while running spank callback: Failed to acquire global options mutex: "Poisoned(..)"

thread '<unnamed>' panicked at /root/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/slurm-spank-0.4.0/src/lib.rs:1044:14:
Failed to acquire global options mutex: "Poisoned(..)"
slurmstepd: error: Caught panic while running spank callback: Failed to acquire global options mutex: "Poisoned(..)"

thread '<unnamed>' panicked at /root/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/slurm-spank-0.4.0/src/lib.rs:1044:14:
Failed to acquire global options mutex: "Poisoned(..)"
slurmstepd: error: Caught panic while running spank callback: Failed to acquire global options mutex: "Poisoned(..)"
Traceback (most recent call last):
  File "/shared/spank-plugins/primitives/python/examples/ibm/sampler.py", line 28, in <module>
    service = QRMIService()
              ^^^^^^^^^^^^^
  File "/shared/pyenv/lib64/python3.12/site-packages/qrmi_primitives/service.py", line 30, in __init__
    qpu_types = os.environ["SLURM_JOB_QPU_TYPES"]
                ~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^
  File "<frozen os>", line 714, in __getitem__
KeyError: 'SLURM_JOB_QPU_TYPES'
srun: error: c1: task 0: Exited with exit code 1

thread '<unnamed>' panicked at /root/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/slurm-spank-0.4.0/src/lib.rs:1044:14:
Failed to acquire global options mutex: "Poisoned(..)"
slurmstepd: error: Caught panic while running spank callback: Failed to acquire global options mutex: "Poisoned(..)"

thread '<unnamed>' panicked at /root/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/slurm-spank-0.4.0/src/lib.rs:1044:14:
Failed to acquire global options mutex: "Poisoned(..)"
slurmstepd: error: Caught panic while running spank callback: Failed to acquire global options mutex: "Poisoned(..)"
```

### New:
```
Traceback (most recent call last):
  File "/shared/spank-plugins/primitives/python/examples/ibm/estimator.py", line 32, in <module>
    raise ValueError("No quantum resource is available.")
ValueError: No quantum resource is available.
```

In /var/log/slurm/slurmd.log
`[2025-05-26T06:30:24.055] [23.batch] error: spank{id="spank_qrmi" cb="slurm_spank_init_post_opt" ctx="Remote"}: missing field `resources` at line 113 column 1`

## Checklist ✅

- [x] Have you included a description of this change?
- [x] Have you updated the relevant documentation to reflect this change?
- [ ] Have you made sure CI is passing before requesting a review?

## Ticket
- [ ] Fixes #
- [ ] Is Part of #
