### PR TITLE
Use GPLv3 source code headers for slurm plugin

### DIFF
--- a/plugins/skeleton/spank_skeleton.c
+++ b/plugins/skeleton/spank_skeleton.c
@@ -3,13 +3,17 @@
  *
  * (C) Copyright IBM 2025.
  *
- * This code is licensed under the Apache License, Version 2.0. You may
- * obtain a copy of this license in the LICENSE.txt file in the root directory
- * of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+ * This program and the accompanying materials are made available under the
+ * terms of the GNU General Public License version 3, as published by the
+ * Free Software Foundation.
  *
- * Any modifications or derivative works of this code must retain this
- * copyright notice, and modified files need to carry a notice indicating
- * that they have been altered from the originals.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <[https://www.gnu.org/licenses/gpl-3.0.txt]
  */
 #include <ctype.h>
 #include <grp.h>

--- a/plugins/skeleton_rust/Cargo.toml
+++ b/plugins/skeleton_rust/Cargo.toml
@@ -2,6 +2,7 @@
 name = "spank-rust-skeleton"
 version = "0.1.0"
 edition = "2021"
+license = "GPL-3.0"
 
 [lib]
 crate-type = ["cdylib"]

--- a/plugins/skeleton_rust/README.md
+++ b/plugins/skeleton_rust/README.md
@@ -13,3 +13,7 @@
 cargo clean
 cargo build --release
 ```
+
+## License
+
+[GPL-3.0](https://github.com/qiskit-community/spank-plugins/blob/main/LICENSE)

--- a/plugins/skeleton_rust/src/lib.rs
+++ b/plugins/skeleton_rust/src/lib.rs
@@ -2,13 +2,17 @@
 //
 // (C) Copyright IBM 2025
 //
-// This code is licensed under the Apache License, Version 2.0. You may
-// obtain a copy of this license in the LICENSE.txt file in the root directory
-// of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+// This program and the accompanying materials are made available under the
+// terms of the GNU General Public License version 3, as published by the
+// Free Software Foundation.
 //
-// Any modifications or derivative works of this code must retain this
-// copyright notice, and modified files need to carry a notice indicating
-// that they have been altered from the originals.
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <[https://www.gnu.org/licenses/gpl-3.0.txt]
 //
 use eyre::WrapErr;
 use slurm_spank::{Context, Plugin, SpankHandle, SpankOption, SLURM_VERSION_NUMBER, SPANK_PLUGIN};

--- a/plugins/spank_qrmi/Cargo.toml
+++ b/plugins/spank_qrmi/Cargo.toml
@@ -2,6 +2,7 @@
 name = "spank-qrmi"
 version = "0.4.0"
 edition = "2021"
+license = "GPL-3.0"
 
 [lib]
 crate-type = ["cdylib"]

--- a/plugins/spank_qrmi/src/lib.rs
+++ b/plugins/spank_qrmi/src/lib.rs
@@ -2,13 +2,17 @@
 //
 // (C) Copyright IBM 2025
 //
-// This code is licensed under the Apache License, Version 2.0. You may
-// obtain a copy of this license in the LICENSE.txt file in the root directory
-// of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+// This program and the accompanying materials are made available under the
+// terms of the GNU General Public License version 3, as published by the
+// Free Software Foundation.
 //
-// Any modifications or derivative works of this code must retain this
-// copyright notice, and modified files need to carry a notice indicating
-// that they have been altered from the originals.
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <[https://www.gnu.org/licenses/gpl-3.0.txt]
 //
 use eyre::{eyre, WrapErr};
 use slurm_spank::{Context, Plugin, SpankHandle, SpankOption, SLURM_VERSION_NUMBER, SPANK_PLUGIN};

--- a/plugins/spank_qrmi/src/models.rs
+++ b/plugins/spank_qrmi/src/models.rs
@@ -2,13 +2,18 @@
 //
 // (C) Copyright IBM 2025
 //
-// This code is licensed under the Apache License, Version 2.0. You may
-// obtain a copy of this license in the LICENSE.txt file in the root directory
-// of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+// This program and the accompanying materials are made available under the
+// terms of the GNU General Public License version 3, as published by the
+// Free Software Foundation.
 //
-// Any modifications or derivative works of this code must retain this
-// copyright notice, and modified files need to carry a notice indicating
-// that they have been altered from the originals.
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <[https://www.gnu.org/licenses/gpl-3.0.txt]
+//
 #![allow(unused_imports)]
 
 mod config;

--- a/plugins/spank_qrmi/src/models/config.rs
+++ b/plugins/spank_qrmi/src/models/config.rs
@@ -2,13 +2,18 @@
 //
 // (C) Copyright IBM 2025
 //
-// This code is licensed under the Apache License, Version 2.0. You may
-// obtain a copy of this license in the LICENSE.txt file in the root directory
-// of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+// This program and the accompanying materials are made available under the
+// terms of the GNU General Public License version 3, as published by the
+// Free Software Foundation.
 //
-// Any modifications or derivative works of this code must retain this
-// copyright notice, and modified files need to carry a notice indicating
-// that they have been altered from the originals.
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <[https://www.gnu.org/licenses/gpl-3.0.txt]
+//
 
 use std::collections::HashMap;
 use std::fmt;

--- a/plugins/spank_qrmi_supp/spank_qrmi_supp.c
+++ b/plugins/spank_qrmi_supp/spank_qrmi_supp.c
@@ -1,15 +1,19 @@
 /*
  * This code is part of Qiskit.
  *
- * (C) Copyright IBM 2025.
+ * (C) Copyright IBM 2025
  *
- * This code is licensed under the Apache License, Version 2.0. You may
- * obtain a copy of this license in the LICENSE.txt file in the root directory
- * of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+ * This program and the accompanying materials are made available under the
+ * terms of the GNU General Public License version 3, as published by the
+ * Free Software Foundation.
  *
- * Any modifications or derivative works of this code must retain this
- * copyright notice, and modified files need to carry a notice indicating
- * that they have been altered from the originals.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <[https://www.gnu.org/licenses/gpl-3.0.txt]
  */
 #include <stdlib.h>
 #include <string.h>
@@ -19,9 +23,9 @@
 #include "slurm/spank.h"
 
 /*
- * Spank plugin for IBM Direct Access(ibmda).
+ * Supplemental Spank plugin to set environment variables not covered by spank_qrmi plugin
  */
-SPANK_PLUGIN(spank_qrmi_ibmda, 1)
+SPANK_PLUGIN(spank_qrmi_supp, 1)
 
 static const size_t DEFAULT_KEYBUF_LEN = 256;
 /*


### PR DESCRIPTION
## Description of Change

<!-- Please include a readable description about the change. -->
We plan to release spank plugin code under GPLv3 license, so that we need to change the current source code header.

## Checklist ✅

- [ ] Have you included a description of this change?
- [ ] Have you updated the relevant documentation to reflect this change?
- [ ] Have you made sure CI is passing before requesting a review?

## Ticket
- [ ] Fixes #
- [ ] Is Part of #
