### PR TITLE
task_runner/examples: Generate primitive params data for IBM QRMI examples

### DIFF
--- a/commands/task_runner/examples/qiskit/README.md
+++ b/commands/task_runner/examples/qiskit/README.md
@@ -1,5 +1,7 @@
 # Tools to generate EstimatorV2/SamplerV2 primitive input
 
+The tools demonstrate the generation of EstimatorV2/SamplerV2 inputs from a quantum circuit example.
+
 ## Prerequisites
 * Python 3.11 or above
 
@@ -16,17 +18,18 @@ pip install -f requirements.txt
 
 Generates EstimatorV2 input for the circuit introduced in [Getting started doc](https://docs.quantum.ibm.com/guides/get-started-with-primitives#get-started-with-estimator).
 
+
 Usage:
 ```shell-session
 usage: gen_estimator_inputs.py [-h] [--iam_url IAM_URL] backend base_url apikey crn
 
-A tool to generate SamplerV2 input for testing
+A tool to generate EstimatorV2 input for testing
 
 positional arguments:
   backend     Backend name
   base_url    API endpoint
   apikey      IAM API key
-  crn         'Service CRN of your instance
+  crn         Service CRN of your instance
 
 options:
   -h, --help  show this help message and exit
@@ -39,7 +42,11 @@ python gen_estimator_input.py ibm_marrakesh https://quantum.cloud.ibm.com/api <y
 ```
 
 Output:
-`estimator_input_{backend name}.json` will be created.
+
+| Files | Descriptions |
+| ---- | ---- |
+| estimator_input_{backend_name}_params_only.json | EstimatorV2 input parameters([EstimatorV2 schema](https://github.com/Qiskit/ibm-quantum-schemas/blob/main/schemas/estimator_v2_schema.json)).
+| estimator_input_{backend_name}.json | An input for QRMI task runner, which contains 2 properties - `program_id`(=`estimator`) and `parameters`(EstimatorV2 input parameters). |
 
 ### gen_sampler_input.py
 
@@ -55,7 +62,7 @@ positional arguments:
   backend     Backend name
   base_url    API endpoint
   apikey      IAM API key
-  crn         'Service CRN of your instance
+  crn         Service CRN of your instance
 
 options:
   -h, --help  show this help message and exit
@@ -68,4 +75,8 @@ python gen_sampler_input.py ibm_marrakesh https://quantum.cloud.ibm.com/api <you
 ```
 
 Output:
-`sampler_input_{backend name}.json` will be created.
+
+| Files | Descriptions |
+| ---- | ---- |
+| sampler_input_{backend_name}_params_only.json | SamplerV2 input parameters([SamplerV2 schema](https://github.com/Qiskit/ibm-quantum-schemas/blob/main/schemas/sampler_v2_schema.json)).
+| sampler_input_{backend_name}.json | An input for QRMI task runner, which contains 2 properties - `program_id`(=`sampler`) and `parameters`(SamplerV2 input parameters). |

--- a/commands/task_runner/examples/qiskit/gen_estimator_inputs.py
+++ b/commands/task_runner/examples/qiskit/gen_estimator_inputs.py
@@ -30,7 +30,7 @@ from qiskit.transpiler.preset_passmanagers import generate_preset_pass_manager
 from qiskit.primitives.containers.estimator_pub import EstimatorPub
 
 parser = argparse.ArgumentParser(
-    description="A tool to generate SamplerV2 input for testing"
+    description="A tool to generate EstimatorV2 input for testing"
 )
 parser.add_argument("backend", help="Backend name")
 parser.add_argument("base_url", help="API endpoint")
@@ -128,15 +128,20 @@ input_json = {
     },
 }
 
-payload_json = {
-    "parameters": input_json,
-    "program_id": "estimator"
-}
+def dump(json_data: dict, filename: str) -> None:
+    """Write json data to the specified file
 
-print(json.dumps(payload_json, cls=RuntimeEncoder, indent=2))
-with open(
-    f"estimator_input_{args.backend}.json", "w", encoding="utf-8"
-) as primitive_input_file:
-    json.dump(payload_json, primitive_input_file, cls=RuntimeEncoder, indent=2)
+    Args:
+        json_data(dict): JSON data
+        filename(str): output filename
+    """
+    print(json.dumps(json_data, cls=RuntimeEncoder, indent=2))
+    with open(filename, "w", encoding="utf-8") as primitive_input_file:
+        json.dump(json_data, primitive_input_file, cls=RuntimeEncoder, indent=2)
 
+dump(
+    {"parameters": input_json, "program_id": "estimator"},
+    f"estimator_input_{args.backend}.json",
+)
+dump(input_json, f"estimator_input_{args.backend}_params_only.json")
 print("done")

--- a/commands/task_runner/examples/qiskit/gen_sampler_inputs.py
+++ b/commands/task_runner/examples/qiskit/gen_sampler_inputs.py
@@ -34,7 +34,7 @@ parser = argparse.ArgumentParser(
 parser.add_argument("backend", help="Backend name")
 parser.add_argument("base_url", help="API endpoint")
 parser.add_argument("apikey", help="IAM API key")
-parser.add_argument("crn", help="'Service CRN of your instance")
+parser.add_argument("crn", help="Service CRN of your instance")
 parser.add_argument(
     "--iam_url", help="IAM endpoint", default="https://iam.cloud.ibm.com"
 )
@@ -120,15 +120,22 @@ input_json = {
     "options": {},
 }
 
-payload_json = {
-    "parameters": input_json,
-    "program_id": "sampler"
-}
 
-print(json.dumps(payload_json, cls=RuntimeEncoder, indent=2))
-with open(
-    f"sampler_input_{args.backend}.json", "w", encoding="utf-8"
-) as primitive_input_file:
-    json.dump(payload_json, primitive_input_file, cls=RuntimeEncoder, indent=2)
+def dump(json_data: dict, filename: str) -> None:
+    """Write json data to the specified file
+
+    Args:
+        json_data(dict): JSON data
+        filename(str): output filename
+    """
+    print(json.dumps(json_data, cls=RuntimeEncoder, indent=2))
+    with open(filename, "w", encoding="utf-8") as primitive_input_file:
+        json.dump(json_data, primitive_input_file, cls=RuntimeEncoder, indent=2)
+
+dump(
+    {"parameters": input_json, "program_id": "sampler"},
+    f"sampler_input_{args.backend}.json",
+)
+dump(input_json, f"sampler_input_{args.backend}_params_only.json")
 
 print("done")

--- a/commands/task_runner/examples/qiskit/requirements.txt
+++ b/commands/task_runner/examples/qiskit/requirements.txt
@@ -1,5 +1,3 @@
-qiskit>=1.4.2
 qiskit_ibm_runtime>=0.30.0
 qiskit_qasm3_import
-numpy
 ibm-cloud-sdk-core

--- a/qrmi/examples/c/direct_access/README.md
+++ b/qrmi/examples/c/direct_access/README.md
@@ -27,6 +27,10 @@ Because QRMI is an environment variable driven software library, all configurati
 
 Refer [this tool](../../../../commands/task_runner/examples/qiskit) to generate. You can customize quantum circuits by editting the code.
 
+> [!NOTE]
+> Use the file with name ending with `_params_only.json`, e.g. `sampler_input_ibm_torino_params_only.json`.
+
+
 ## How to build this example
 
 ```shell-session

--- a/qrmi/examples/c/qiskit_runtime_service/README.md
+++ b/qrmi/examples/c/qiskit_runtime_service/README.md
@@ -24,6 +24,9 @@ Because QRMI is an environment variable driven software library, all configurati
 
 Refer [this tool](../../../../commands/task_runner/examples/qiskit) to generate. You can customize quantum circuits by editting the code.
 
+> [!NOTE]
+> Use the file with name ending with `_params_only.json`, e.g. `sampler_input_ibm_torino_params_only.json`.
+
 ## How to build this example
 
 ```shell-session

--- a/qrmi/examples/python/direct_access/README.md
+++ b/qrmi/examples/python/direct_access/README.md
@@ -34,6 +34,9 @@ Because QRMI is an environment variable driven software library, all configurati
 
 Refer [this tool](../../../../commands/task_runner/examples/qiskit) to generate. You can customize quantum circuits by editting the code.
 
+> [!NOTE]
+> Use the file with name ending with `_params_only.json`, e.g. `sampler_input_ibm_torino_params_only.json`.
+
 ## How to run
 
 ```shell-session

--- a/qrmi/examples/python/qiskit_runtime_service/README.md
+++ b/qrmi/examples/python/qiskit_runtime_service/README.md
@@ -27,9 +27,13 @@ Because QRMI is an environment variable driven software library, all configurati
 | {resource_name}_QRMI_IBM_QRS_SESSION_MAX_TTL | The maximum time (in seconds) for the session to run, subject to plan limits, default: `28800`. |
 | {resource_name}_QRMI_IBM_QRS_TIMEOUT_SECONDS | (Optional) Cost of the job as the estimated time it should take to complete (in seconds). Should not exceed the cost of the program, default: `None`. |
 | {resource_name}_QRMI_IBM_QRS_SESSION_ID | (Optional) Session ID, can be obtanied by acquire function. If exists, used in the target functions. |
+
 ## Create Qiskit Primitive input file as input
 
 Refer [this tool](../../../../commands/task_runner/examples/qiskit) to generate. You can customize quantum circuits by editting the code.
+
+> [!NOTE]
+> Use the file with name ending with `_params_only.json`, e.g. `sampler_input_ibm_torino_params_only.json`.
 
 ## How to run
 

--- a/qrmi/examples/rust/direct_access/README.md
+++ b/qrmi/examples/rust/direct_access/README.md
@@ -27,6 +27,9 @@ Because QRMI is an environment variable driven software library, all configurati
 
 Refer [this tool](../../../../commands/task_runner/examples/qiskit) to generate. You can customize quantum circuits by editting the code.
 
+> [!NOTE]
+> Use the file with name ending with `_params_only.json`, e.g. `sampler_input_ibm_torino_params_only.json`.
+
 ## How to build this example
 
 ```shell-session

--- a/qrmi/examples/rust/qiskit_runtime_service/README.md
+++ b/qrmi/examples/rust/qiskit_runtime_service/README.md
@@ -24,6 +24,9 @@ Because QRMI is an environment variable driven software library, all configurati
 
 Refer [this tool](../../../../commands/task_runner/examples/qiskit) to generate. You can customize quantum circuits by editting the code.
 
+> [!NOTE]
+> Use the file with name ending with `_params_only.json`, e.g. `sampler_input_ibm_torino_params_only.json`.
+
 ## How to build this example
 
 ```shell-session


### PR DESCRIPTION
## Description of Change

<!-- Please include a readable description about the change. -->
The problem was reported by user in #101 . 

This problem is caused by recent task runner implementation #85. Input data format expected by task runner for IBM QRMI is:

```
{
    "program_id": "sampler",
    "parameters": { "pubs": "abc", ...... }
}
```

which is now different from ones expected by IBM's QRMI examples which are expecting uses to specify [EstimatorV2](https://github.com/Qiskit/ibm-quantum-schemas/blob/main/schemas/estimator_v2_schema.json) & [Sampler V2](https://github.com/Qiskit/ibm-quantum-schemas/blob/main/schemas/sampler_v2_schema.json) input parameters.

This PR will enhance [gen_estimator_input.py](https://github.com/qiskit-community/spank-plugins/blob/main/commands/task_runner/examples/qiskit/gen_estimator_inputs.py) and [gen_sampler_input.py](https://github.com/qiskit-community/spank-plugins/blob/main/commands/task_runner/examples/qiskit/gen_sampler_inputs.py) to generate 2 types of input data - one is for QRMI task runner currently implemented, another is generating Qiskit EstimatorV2/SamplerV2 input parameters only like below.

```
{
    "pubs": "abc",
    ......
}

```
IBM's QRMI example documentation has been updated to include a reminder to users to ensure that files ending in “`_params_only.json`” are used.



## Checklist ✅

- [x] Have you included a description of this change?
- [x] Have you updated the relevant documentation to reflect this change?
- [ ] Have you made sure CI is passing before requesting a review?

## Ticket
- [ ] Fixes #
- [ ] Is Part of #
