### PR TITLE
Update qiskit example to fix Qiskit 2.1 deprecation warning

### DIFF
--- a/commands/task_runner/examples/qiskit/README.md
+++ b/commands/task_runner/examples/qiskit/README.md
@@ -1,5 +1,7 @@
 # Tools to generate EstimatorV2/SamplerV2 primitive input
 
+The tools demonstrate the generation of EstimatorV2/SamplerV2 inputs from a quantum circuit example.
+
 ## Prerequisites
 * Python 3.11 or above
 
@@ -16,17 +18,18 @@ pip install -f requirements.txt
 
 Generates EstimatorV2 input for the circuit introduced in [Getting started doc](https://docs.quantum.ibm.com/guides/get-started-with-primitives#get-started-with-estimator).
 
+
 Usage:
 ```shell-session
 usage: gen_estimator_inputs.py [-h] [--iam_url IAM_URL] backend base_url apikey crn
 
-A tool to generate SamplerV2 input for testing
+A tool to generate EstimatorV2 input for testing
 
 positional arguments:
   backend     Backend name
   base_url    API endpoint
   apikey      IAM API key
-  crn         'Service CRN of your instance
+  crn         Service CRN of your instance
 
 options:
   -h, --help  show this help message and exit
@@ -39,7 +42,11 @@ python gen_estimator_input.py ibm_marrakesh https://quantum.cloud.ibm.com/api <y
 ```
 
 Output:
-`estimator_input_{backend name}.json` will be created.
+
+| Files | Descriptions |
+| ---- | ---- |
+| estimator_input_{backend_name}_params_only.json | EstimatorV2 input parameters([EstimatorV2 schema](https://github.com/Qiskit/ibm-quantum-schemas/blob/main/schemas/estimator_v2_schema.json)).
+| estimator_input_{backend_name}.json | An input for QRMI task runner, which contains 2 properties - `program_id`(=`estimator`) and `parameters`(EstimatorV2 input parameters). |
 
 ### gen_sampler_input.py
 
@@ -55,7 +62,7 @@ positional arguments:
   backend     Backend name
   base_url    API endpoint
   apikey      IAM API key
-  crn         'Service CRN of your instance
+  crn         Service CRN of your instance
 
 options:
   -h, --help  show this help message and exit
@@ -68,4 +75,8 @@ python gen_sampler_input.py ibm_marrakesh https://quantum.cloud.ibm.com/api <you
 ```
 
 Output:
-`sampler_input_{backend name}.json` will be created.
+
+| Files | Descriptions |
+| ---- | ---- |
+| sampler_input_{backend_name}_params_only.json | SamplerV2 input parameters([SamplerV2 schema](https://github.com/Qiskit/ibm-quantum-schemas/blob/main/schemas/sampler_v2_schema.json)).
+| sampler_input_{backend_name}.json | An input for QRMI task runner, which contains 2 properties - `program_id`(=`sampler`) and `parameters`(SamplerV2 input parameters). |

--- a/commands/task_runner/examples/qiskit/gen_estimator_inputs.py
+++ b/commands/task_runner/examples/qiskit/gen_estimator_inputs.py
@@ -30,7 +30,7 @@ from qiskit.transpiler.preset_passmanagers import generate_preset_pass_manager
 from qiskit.primitives.containers.estimator_pub import EstimatorPub
 
 parser = argparse.ArgumentParser(
-    description="A tool to generate SamplerV2 input for testing"
+    description="A tool to generate EstimatorV2 input for testing"
 )
 parser.add_argument("backend", help="Backend name")
 parser.add_argument("base_url", help="API endpoint")
@@ -128,15 +128,20 @@ input_json = {
     },
 }
 
-payload_json = {
-    "parameters": input_json,
-    "program_id": "estimator"
-}
+def dump(json_data: dict, filename: str) -> None:
+    """Write json data to the specified file
 
-print(json.dumps(payload_json, cls=RuntimeEncoder, indent=2))
-with open(
-    f"estimator_input_{args.backend}.json", "w", encoding="utf-8"
-) as primitive_input_file:
-    json.dump(payload_json, primitive_input_file, cls=RuntimeEncoder, indent=2)
+    Args:
+        json_data(dict): JSON data
+        filename(str): output filename
+    """
+    print(json.dumps(json_data, cls=RuntimeEncoder, indent=2))
+    with open(filename, "w", encoding="utf-8") as primitive_input_file:
+        json.dump(json_data, primitive_input_file, cls=RuntimeEncoder, indent=2)
 
+dump(
+    {"parameters": input_json, "program_id": "estimator"},
+    f"estimator_input_{args.backend}.json",
+)
+dump(input_json, f"estimator_input_{args.backend}_params_only.json")
 print("done")

--- a/commands/task_runner/examples/qiskit/gen_sampler_inputs.py
+++ b/commands/task_runner/examples/qiskit/gen_sampler_inputs.py
@@ -34,7 +34,7 @@ parser = argparse.ArgumentParser(
 parser.add_argument("backend", help="Backend name")
 parser.add_argument("base_url", help="API endpoint")
 parser.add_argument("apikey", help="IAM API key")
-parser.add_argument("crn", help="'Service CRN of your instance")
+parser.add_argument("crn", help="Service CRN of your instance")
 parser.add_argument(
     "--iam_url", help="IAM endpoint", default="https://iam.cloud.ibm.com"
 )
@@ -120,15 +120,22 @@ input_json = {
     "options": {},
 }
 
-payload_json = {
-    "parameters": input_json,
-    "program_id": "sampler"
-}
 
-print(json.dumps(payload_json, cls=RuntimeEncoder, indent=2))
-with open(
-    f"sampler_input_{args.backend}.json", "w", encoding="utf-8"
-) as primitive_input_file:
-    json.dump(payload_json, primitive_input_file, cls=RuntimeEncoder, indent=2)
+def dump(json_data: dict, filename: str) -> None:
+    """Write json data to the specified file
+
+    Args:
+        json_data(dict): JSON data
+        filename(str): output filename
+    """
+    print(json.dumps(json_data, cls=RuntimeEncoder, indent=2))
+    with open(filename, "w", encoding="utf-8") as primitive_input_file:
+        json.dump(json_data, primitive_input_file, cls=RuntimeEncoder, indent=2)
+
+dump(
+    {"parameters": input_json, "program_id": "sampler"},
+    f"sampler_input_{args.backend}.json",
+)
+dump(input_json, f"sampler_input_{args.backend}_params_only.json")
 
 print("done")

--- a/commands/task_runner/examples/qiskit/requirements.txt
+++ b/commands/task_runner/examples/qiskit/requirements.txt
@@ -1,5 +1,3 @@
-qiskit>=1.4.2
 qiskit_ibm_runtime>=0.30.0
 qiskit_qasm3_import
-numpy
 ibm-cloud-sdk-core

--- a/docs/ux.md
+++ b/docs/ux.md
@@ -86,13 +86,13 @@ HPC applications use the Slurm QPU resources assigned to the Slurm job.
 
 Environment variables provide more details for use by the appliction, e.g. `SLURM_JOB_QPU_RESOURCES` listing the quantum resource names (comma separated if there are several provided).
 These variables will be used by QRMI.
-See the README files in the various QRMI flavor directories ([Direct Access](../primitives/python/examples/direct_access/README.md), [Qiskit Runtime Service](../primitives/python/examples/qiskit_runtime_service/README.md)) for details.
+See the README files in the various QRMI flavor directories ([Direct Access](../primitives/python/qiskit_qrmi_primitives/examples/ibm/direct_access/README.md), [Qiskit Runtime Service](../primitives/python/qiskit_qrmi_primitives/examples/ibm/qiskit_runtime_service/README.md)) for details.
 
 ```python
 from qiskit import QuantumCircuit
-from qrmi_primitives import QRMIService
+from qiskit_qrmi_primitives import QRMIService
 # using an IBM QRMI flavor:
-from qrmi_primitives.ibm import SamplerV2
+from qiskit_qrmi_primitives.ibm import SamplerV2
 
 # define circuit
 
@@ -129,7 +129,7 @@ result = job.result()
 print(f">>> {result}")
 ```
 
-See [examples directory](../primitives/python/examples/) for example files.
+See [examples directory](../primitives/python/qiskit_qrmi_primitives/examples/) for example files.
 
 ### Backend specifics
 #### IBM Direct Access API

--- a/primitives/python/qiskit_qrmi_primitives/examples/ibm/sampler.py
+++ b/primitives/python/qiskit_qrmi_primitives/examples/ibm/sampler.py
@@ -16,7 +16,7 @@
 import random
 import numpy as np
 from dotenv import load_dotenv
-from qiskit.circuit.library import EfficientSU2
+from qiskit.circuit.library import efficient_su2
 from qiskit.transpiler.preset_passmanagers import generate_preset_pass_manager
 from qiskit_qrmi_primitives import QRMIService
 from qiskit_qrmi_primitives.ibm import SamplerV2
@@ -39,7 +39,7 @@ print(qrmi.metadata())
 target = get_target(qrmi)
 
 # Create a circuit - You need at least one circuit as the input to the Sampler primitive.
-circuit = EfficientSU2(127, entanglement="linear", flatten=True)
+circuit = efficient_su2(127, entanglement="linear")
 circuit.measure_all()
 # The circuit is parametrized, so we will define the parameter values for execution
 param_values = np.random.rand(circuit.num_parameters)

--- a/qrmi/examples/c/direct_access/README.md
+++ b/qrmi/examples/c/direct_access/README.md
@@ -27,6 +27,10 @@ Because QRMI is an environment variable driven software library, all configurati
 
 Refer [this tool](../../../../commands/task_runner/examples/qiskit) to generate. You can customize quantum circuits by editting the code.
 
+> [!NOTE]
+> Use the file with name ending with `_params_only.json`, e.g. `sampler_input_ibm_torino_params_only.json`.
+
+
 ## How to build this example
 
 ```shell-session

--- a/qrmi/examples/c/qiskit_runtime_service/README.md
+++ b/qrmi/examples/c/qiskit_runtime_service/README.md
@@ -24,6 +24,9 @@ Because QRMI is an environment variable driven software library, all configurati
 
 Refer [this tool](../../../../commands/task_runner/examples/qiskit) to generate. You can customize quantum circuits by editting the code.
 
+> [!NOTE]
+> Use the file with name ending with `_params_only.json`, e.g. `sampler_input_ibm_torino_params_only.json`.
+
 ## How to build this example
 
 ```shell-session

--- a/qrmi/examples/python/direct_access/README.md
+++ b/qrmi/examples/python/direct_access/README.md
@@ -34,6 +34,9 @@ Because QRMI is an environment variable driven software library, all configurati
 
 Refer [this tool](../../../../commands/task_runner/examples/qiskit) to generate. You can customize quantum circuits by editting the code.
 
+> [!NOTE]
+> Use the file with name ending with `_params_only.json`, e.g. `sampler_input_ibm_torino_params_only.json`.
+
 ## How to run
 
 ```shell-session

--- a/qrmi/examples/python/qiskit_runtime_service/README.md
+++ b/qrmi/examples/python/qiskit_runtime_service/README.md
@@ -27,9 +27,13 @@ Because QRMI is an environment variable driven software library, all configurati
 | {resource_name}_QRMI_IBM_QRS_SESSION_MAX_TTL | The maximum time (in seconds) for the session to run, subject to plan limits, default: `28800`. |
 | {resource_name}_QRMI_IBM_QRS_TIMEOUT_SECONDS | (Optional) Cost of the job as the estimated time it should take to complete (in seconds). Should not exceed the cost of the program, default: `None`. |
 | {resource_name}_QRMI_IBM_QRS_SESSION_ID | (Optional) Session ID, can be obtanied by acquire function. If exists, used in the target functions. |
+
 ## Create Qiskit Primitive input file as input
 
 Refer [this tool](../../../../commands/task_runner/examples/qiskit) to generate. You can customize quantum circuits by editting the code.
+
+> [!NOTE]
+> Use the file with name ending with `_params_only.json`, e.g. `sampler_input_ibm_torino_params_only.json`.
 
 ## How to run
 

--- a/qrmi/examples/rust/direct_access/README.md
+++ b/qrmi/examples/rust/direct_access/README.md
@@ -27,6 +27,9 @@ Because QRMI is an environment variable driven software library, all configurati
 
 Refer [this tool](../../../../commands/task_runner/examples/qiskit) to generate. You can customize quantum circuits by editting the code.
 
+> [!NOTE]
+> Use the file with name ending with `_params_only.json`, e.g. `sampler_input_ibm_torino_params_only.json`.
+
 ## How to build this example
 
 ```shell-session

--- a/qrmi/examples/rust/qiskit_runtime_service/README.md
+++ b/qrmi/examples/rust/qiskit_runtime_service/README.md
@@ -24,6 +24,9 @@ Because QRMI is an environment variable driven software library, all configurati
 
 Refer [this tool](../../../../commands/task_runner/examples/qiskit) to generate. You can customize quantum circuits by editting the code.
 
+> [!NOTE]
+> Use the file with name ending with `_params_only.json`, e.g. `sampler_input_ibm_torino_params_only.json`.
+
 ## How to build this example
 
 ```shell-session


### PR DESCRIPTION
## Description of Change

<!-- Please include a readable description about the change. -->
Fix DeprecationWarning caused when running sampler example with qiskit 2.1 modules.

`slurm-2.out:/shared/spank-plugins/primitives/python/qiskit_qrmi_primitives/examples/ibm/sampler.py:42: DeprecationWarning: The class ``qiskit.circuit.library.n_local.efficient_su2.EfficientSU2`` is deprecated as of Qiskit 2.1. It will be removed in Qiskit 3.0. Use the function qiskit.circuit.library.efficient_su2 instead.`

## Checklist ✅

- [x] Have you included a description of this change?
- [ ] Have you updated the relevant documentation to reflect this change?
- [ ] Have you made sure CI is passing before requesting a review?

## Ticket
- [ ] Fixes #
- [ ] Is Part of #
