### PR TITLE
Update qiskit example to fix Qiskit 2.1 deprecation

### DIFF
--- a/commands/task_runner/examples/qiskit/gen_sampler_inputs.py
+++ b/commands/task_runner/examples/qiskit/gen_sampler_inputs.py
@@ -26,7 +26,7 @@ from ibm_cloud_sdk_core.authenticators import IAMAuthenticator
 from qiskit import qasm3
 from qiskit.transpiler.preset_passmanagers import generate_preset_pass_manager
 from qiskit.primitives.containers.sampler_pub import SamplerPub
-from qiskit.circuit.library import EfficientSU2
+from qiskit.circuit.library import efficient_su2
 
 parser = argparse.ArgumentParser(
     description="A tool to generate SamplerV2 input for testing"
@@ -85,7 +85,7 @@ pm = generate_preset_pass_manager(
 )
 
 # Create a circuit - You need at least one circuit as the input to the Sampler primitive.
-circuit = EfficientSU2(127, entanglement="linear", flatten=True)
+circuit = efficient_su2(127, entanglement="linear")
 circuit.measure_all()
 # The circuit is parametrized, so we will define the parameter values for execution
 param_values = np.random.rand(circuit.num_parameters)

--- a/primitives/python/qiskit_qrmi_primitives/examples/ibm/sampler.py
+++ b/primitives/python/qiskit_qrmi_primitives/examples/ibm/sampler.py
@@ -16,7 +16,7 @@
 import random
 import numpy as np
 from dotenv import load_dotenv
-from qiskit.circuit.library import EfficientSU2
+from qiskit.circuit.library import efficient_su2
 from qiskit.transpiler.preset_passmanagers import generate_preset_pass_manager
 from qiskit_qrmi_primitives import QRMIService
 from qiskit_qrmi_primitives.ibm import SamplerV2
@@ -39,7 +39,7 @@ print(qrmi.metadata())
 target = get_target(qrmi)
 
 # Create a circuit - You need at least one circuit as the input to the Sampler primitive.
-circuit = EfficientSU2(127, entanglement="linear", flatten=True)
+circuit = efficient_su2(127, entanglement="linear")
 circuit.measure_all()
 # The circuit is parametrized, so we will define the parameter values for execution
 param_values = np.random.rand(circuit.num_parameters)


### PR DESCRIPTION
## Description of Change

<!-- Please include a readable description about the change. -->
Fix DeprecationWarning caused when running sampler example with qiskit 2.1 modules.

`slurm-2.out:/shared/spank-plugins/primitives/python/qiskit_qrmi_primitives/examples/ibm/sampler.py:42: DeprecationWarning: The class ``qiskit.circuit.library.n_local.efficient_su2.EfficientSU2`` is deprecated as of Qiskit 2.1. It will be removed in Qiskit 3.0. Use the function qiskit.circuit.library.efficient_su2 instead.`

## Checklist ✅

- [x] Have you included a description of this change?
- [ ] Have you updated the relevant documentation to reflect this change?
- [ ] Have you made sure CI is passing before requesting a review?

## Ticket
- [ ] Fixes #
- [ ] Is Part of #
