### PR TITLE
Add a tool to validate Slurm plugins

### DIFF
--- a/plugins/tests/metadata/README.md
+++ b/plugins/tests/metadata/README.md
@@ -1,0 +1,28 @@
+# A tool to validate Slurm plugin symbols
+
+This is a verification tool that checks whether a given Slurm plugin library file contains the required metadata symbols.
+
+## Build
+
+Assuming `libslurmfull.so` is available under `/lib64/slurm` directory,
+
+```bash
+gcc -o test test.c -ldl -lslurmfull -L/lib64/slurm
+```
+
+## Run
+
+Assuming `libslurmfull.so` is available under `/lib64/slurm` directory,
+
+```bash
+LD_LIBRARY_PATH=/lib64/slurm:$LD_LIBRARY_PATH ./test <plugin library>
+```
+
+Example:
+
+If SPANK plugin is specified to validate, `type` should be `spank`.
+
+```bash
+$ LD_LIBRARY_PATH=/lib64/slurm:$LD_LIBRARY_PATH ./test ../../spank_qrmi/target/release/libspank_qrmi.so
+Valid Slurm plugin library. name=spank_qrmi, type=spank, version=0xa6358c80
+```

--- a/plugins/tests/metadata/test.c
+++ b/plugins/tests/metadata/test.c
@@ -1,0 +1,62 @@
+/*
+ * This code is part of Qiskit.
+ *
+ * (C) Copyright IBM 2025.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the GNU General Public License version 3, as published by the
+ * Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <[https://www.gnu.org/licenses/gpl-3.0.txt]
+ */
+#include <stdio.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
+#include <dlfcn.h>
+
+int main(int argc, char** argv)
+{
+    void *handle;
+    char *type, *name;
+    uint32_t *version;
+
+    if (argc != 2) {
+        printf("(E) Missing argument. Specify path to plugin library file.\n");
+        exit(EXIT_FAILURE);
+    }
+
+    handle = dlopen(argv[1], RTLD_LAZY);
+    if (handle == NULL) {
+        printf("(E) %s\n", dlerror());
+        exit(EXIT_FAILURE);
+    }
+
+    if (!(name = dlsym(handle, "plugin_name"))) {
+        printf("(E) `plugin_name` symbol not found in %s: %s.\n", argv[1], dlerror());
+        goto error;
+    }
+    if (!(type = dlsym(handle, "plugin_type"))) {
+        printf("(E) `plugin_type` symbol not found in %s: %s.\n", argv[1], dlerror());
+        goto error;
+    }
+    if (!(version = dlsym(handle, "plugin_version"))) {
+        printf("(E) `plugin_version` symbol not found in %s: %s.\n", argv[1], dlerror());
+        goto error;
+    }
+
+    printf("Valid Slurm plugin library. name=%s, type=%s, version=0x%x\n", name, type, version);
+    dlclose(handle);
+
+    return 0;
+
+error:
+    dlclose(handle);
+    exit(EXIT_FAILURE);
+}


### PR DESCRIPTION
## Description of Change

<!-- Please include a readable description about the change. -->
A tool to verify if a built spank plugin is a loadable Slurm plugin. By using this tool before actually deploying to the Slurm cluster, you can detect missing dependent libraries or build problems at an early stage.

## Checklist ✅

- [x] Have you included a description of this change?
- [ ] Have you updated the relevant documentation to reflect this change?
- [ ] Have you made sure CI is passing before requesting a review?

## Ticket
- [ ] Fixes #
- [ ] Is Part of #
