### PR TITLE
Add descriptions on IQP account type to be used when running qiskit-runtime-service jobs

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -14,7 +14,7 @@ Refer each README file to know pre-requisites.
 ## Steps
 
 
-### 1. Install SPANK Plugin
+### 1. Install QRMI
 
 Refer [How to build & install QRMI Python package](https://github.com/qiskit-community/qrmi/blob/main/INSTALL.md#how-to-build--install-qrmi-python-package) and create a wheel file for distribution. Then install.
 

--- a/plugins/spank_qrmi/README.md
+++ b/plugins/spank_qrmi/README.md
@@ -70,8 +70,8 @@ If a user specifies a resource with the --qpu option that is not defined in the 
 If the user sets the necessary environment variables for job execution themselves, it is not required to specify them in this file. In this case, the environment property will be `{}`.
 
 > [!NOTE]
-> If you are using a QPU resource with the resource type `qiskit-runtime-service`, please use an account that supports session creation, such as a Premium plan.
-> If you are using an account that does not support session creation, such as an Open plan account, please add the following environment variable to the list in qrmi_config.json:
+> If you are using a QPU resource with the resource type `qiskit-runtime-service`, use an account that supports [opening a session](https://quantum.cloud.ibm.com/docs/en/guides/run-jobs-session#open-a-session), such as a Premium plan.
+> If you are using an account that does not support opening a session, such as an Open plan account, add the following environment variable to the list in qrmi_config.json as workaround:
 > `QRMI_IBM_QRS_SESSION_MODE="batch"`
 
 ## Installation

--- a/plugins/spank_qrmi/README.md
+++ b/plugins/spank_qrmi/README.md
@@ -71,8 +71,7 @@ If the user sets the necessary environment variables for job execution themselve
 
 > [!NOTE]
 > If you are using a QPU resource with the resource type `qiskit-runtime-service`, use an account that supports [opening a session](https://quantum.cloud.ibm.com/docs/en/guides/run-jobs-session#open-a-session), such as a Premium plan.
-> If you are using an account that does not support opening a session, such as an Open plan account, add the following environment variable to the list in qrmi_config.json as workaround:
-> `QRMI_IBM_QRS_SESSION_MODE="batch"`
+> If you are using an account that does not support opening a session, such as an Open plan account, add `QRMI_IBM_QRS_SESSION_MODE="batch"` to the environment variable list in qrmi_config.json as workaround:
 
 ## Installation
 

--- a/plugins/spank_qrmi/README.md
+++ b/plugins/spank_qrmi/README.md
@@ -69,6 +69,11 @@ If a user specifies a resource with the --qpu option that is not defined in the 
 
 If the user sets the necessary environment variables for job execution themselves, it is not required to specify them in this file. In this case, the environment property will be `{}`.
 
+> [!NOTE]
+> If you are using a QPU resource with the resource type `qiskit-runtime-service`, please use an account that supports session creation, such as a Premium plan.
+> If you are using an account that does not support session creation, such as an Open plan account, please add the following environment variable to the list in qrmi_config.json:
+> `QRMI_IBM_QRS_SESSION_MODE="batch"`
+
 ## Installation
 
 If the above build step is successful, a Linux shared library named `spank_qrmi.so` will be created under the `build/` directory. 


### PR DESCRIPTION
## Description of Change

<!-- Please include a readable description about the change. -->
Add a note to describe IQP account type to be used to run the jobs against qiskit-runtime-service QPU resources.

> If user is using a QPU resource with the resource type qiskit-runtime-service, use an account that supports session creation, such as a Premium plan.
> If user is using an account that does not support session creation, such as an Open plan account, add the following environment variable to the list in qrmi_config.json:
> QRMI_IBM_QRS_SESSION_MODE="batch"

## Checklist ✅

- [x] Have you included a description of this change?
- [x] Have you updated the relevant documentation to reflect this change?
- [ ] Have you made sure CI is passing before requesting a review?

## Ticket
- [ ] Fixes #
- [ ] Is Part of #
