### PR TITLE
Fix build errors by some versions of C compiler

### DIFF
--- a/plugins/spank_qrmi/spank_qrmi.c
+++ b/plugins/spank_qrmi/spank_qrmi.c
@@ -64,7 +64,11 @@ static int _qpu_names_opt_cb(int val, const char *optarg, int remote) {
     UNUSED_PARAM(remote);
     size_t buflen = strlen(optarg) + 1;
     g_qpu_names_opt = (char *)malloc(buflen);
-    strncpy(g_qpu_names_opt, optarg, buflen);
+    /*
+     * use strcpy() to fix the error - ‘strncpy’ specified bound depends on the length of the
+     * source argument - caused by some C compilers.
+     */
+    (void)strcpy(g_qpu_names_opt, optarg);
     slurm_debug("%s: --qpu=[%s]", plugin_name, g_qpu_names_opt);
     return SLURM_SUCCESS;
 }
@@ -185,8 +189,11 @@ int slurm_spank_init_post_opt(spank_t spank_ctxt, int argc, char **argv) {
     /*
      * Copy option string to bufp because subsequent strtok_r will
      * modify the source buffer.
+     *
+     * use strcpy() to fix the error - ‘strncpy’ specified bound depends on the length of the
+     * source argument - caused by some C compilers.
      */
-    strncpy(bufp, g_qpu_names_opt, buflen);
+    (void)strcpy(bufp, g_qpu_names_opt);
 
     while ((token = strtok_r(rest, ",", &rest))) {
         QrmiResourceDef *res = qrmi_config_resource_def_get(cnf, token);
@@ -479,16 +486,20 @@ int slurm_spank_exit(spank_t spank_ctxt, int argc, char **argv) {
  */
 static qpu_resource_t *_acquired_resource_create(char *name, QrmiResourceType type,
                                                  const char *token) {
+    /*
+     * use strcpy() to fix the error - ‘strncpy’ specified bound depends on the length of the
+     * source argument - caused by some C compilers.
+     */
     qpu_resource_t *info = malloc(sizeof(qpu_resource_t));
     size_t buflen = strlen(name) + 1;
     char *bufp = (char *)malloc(buflen);
-    strncpy(bufp, name, buflen);
+    (void)strcpy(bufp, name);
     info->name = bufp;
     info->type = type;
 
     buflen = strlen(token) + 1;
     bufp = (char *)malloc(buflen);
-    strncpy(bufp, token, buflen);
+    (void)strcpy(bufp, token);
     info->acquisition_token = bufp;
 
     return info;
@@ -534,10 +545,6 @@ static qpu_resource_t *_acquire_qpu(char *name, QrmiResourceType type) {
             slurm_debug("%s, acquisition_token: %s", plugin_name,
                         acquisition_token);
             record = _acquired_resource_create(name, type, acquisition_token);
-
-        } else {
-            slurm_error("%s, failed to acquire resource: %s", plugin_name,
-                        name);
         }
         qrmi_resource_free(qrmi);
     } else {

--- a/plugins/tests/metadata/CMakeLists.txt
+++ b/plugins/tests/metadata/CMakeLists.txt
@@ -52,6 +52,7 @@ function(add_example TARGET_NAME C_FILE)
 
   add_executable(${TARGET_NAME} ${SRC_FILE})
 
+  target_link_libraries(${TARGET_NAME} PUBLIC "-ldl")
   target_compile_options(${TARGET_NAME}
 	  PRIVATE
 	  -Wall -Wextra -Werror -O2 -pedantic -Wconversion -Wwrite-strings


### PR DESCRIPTION
## Description of Change

<!-- Please include a readable description about the change. -->
Fixed build errors caused by old C compiler versions. 

### 1st issue resolved by this PR.
```
/gpfs/u/home/QNTM/QNTMohmn/barn/spank-plugins/plugins/spank_qrmi/spank_qrmi.c:67:5: error: 'strncpy' specified bound depends on the length of the source argument [-Werror=stringop-overflow=]
     strncpy(g_qpu_names_opt, optarg, buflen);
     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/gpfs/u/home/QNTM/QNTMohmn/barn/spank-plugins/plugins/spank_qrmi/spank_qrmi.c:65:21: note: length computed here
     size_t buflen = strlen(optarg) + 1;
                     ^~~~~~~~~~~~~~
```

### 2nd issue resolved by this PR.
```
CMakeFiles/test.dir/src/test.c.o: In function `main':
test.c:(.text.startup+0x30): undefined reference to `dlopen'
test.c:(.text.startup+0x50): undefined reference to `dlsym'
test.c:(.text.startup+0x6c): undefined reference to `dlsym'
test.c:(.text.startup+0x88): undefined reference to `dlsym'
test.c:(.text.startup+0xc4): undefined reference to `dlclose'
test.c:(.text.startup+0x120): undefined reference to `dlerror'
test.c:(.text.startup+0x144): undefined reference to `dlclose'
test.c:(.text.startup+0x15c): undefined reference to `dlerror'
test.c:(.text.startup+0x184): undefined reference to `dlerror'
test.c:(.text.startup+0x1a8): undefined reference to `dlerror'
collect2: error: ld returned 1 exit status
make[2]: *** [CMakeFiles/test.dir/build.make:97: test] Error 1
make[1]: *** [CMakeFiles/Makefile2:83: CMakeFiles/test.dir/all] Error 2
make: *** [Makefile:136: all] Error 2
```

## Checklist ✅

- [x] Have you included a description of this change?
- [ ] Have you updated the relevant documentation to reflect this change?
- [ ] Have you made sure CI is passing before requesting a review?

## Ticket
- [ ] Fixes #
- [ ] Is Part of #
