### PR TITLE
Add error handling if qrmi_config.json not found

### DIFF
--- a/plugins/spank_qrmi/spank_qrmi.c
+++ b/plugins/spank_qrmi/spank_qrmi.c
@@ -158,7 +158,7 @@ int slurm_spank_init_post_opt(spank_t spank_ctxt, int argc, char **argv) {
     if (spank_get_item(spank_ctxt, S_JOB_STEPID, &job_stepid) ==
         ESPANK_SUCCESS) {
         /* skip if this is slurm task steps */
-        slurm_debug("%s, %x", plugin_name, job_stepid);
+        slurm_debug("%s, job_stepid = %x", plugin_name, job_stepid);
         if (job_stepid != SLURM_BATCH_SCRIPT) {
             return SLURM_SUCCESS;
         }
@@ -176,7 +176,16 @@ int slurm_spank_init_post_opt(spank_t spank_ctxt, int argc, char **argv) {
         slurm_debug("%s: argv[%d] = [%s]", plugin_name, i, argv[i]);
     }
 
+    if (argc == 0) {
+        slurm_error("%s, QRMI config file not specified to plugin args", plugin_name);
+        return SLURM_ERROR;
+    }
+
     QrmiConfig *cnf = qrmi_config_load(argv[0]);
+    if (cnf == NULL) {
+        slurm_error("%s, No QRMI config file (%s)", plugin_name, argv[0]);
+        return SLURM_ERROR;
+    }
     slurm_debug("%s, config: %p", plugin_name, (void *)cnf);
 
     size_t buflen = strlen(g_qpu_names_opt) + 1;


### PR DESCRIPTION
## Description of Change

<!-- Please include a readable description about the change. -->
Add error handling for the following cases:
- Path to qrmi_config.json is not specified in plugstack.conf for remote context node
- qrmi_config.json could not be found even though it is specified in plugstack.conf file.

## Checklist ✅

- [x] Have you included a description of this change?
- [ ] Have you updated the relevant documentation to reflect this change?
- [ ] Have you made sure CI is passing before requesting a review?

## Ticket
- [ ] Fixes #
- [ ] Is Part of #
