### PR TITLE
[Pasqal, Docs] add example and instructions for CUDA-Q jobs

### DIFF
--- a/demo/qrmi/jobs/run_cudaq_pasqal.sh
+++ b/demo/qrmi/jobs/run_cudaq_pasqal.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+#SBATCH --job-name=cudaq_pasqal_job
+#SBATCH --output=/data/job_%j.out
+#SBATCH --error=/data/job_%j.out
+#SBATCH --ntasks=1
+#SBATCH --cpus-per-task=1
+#SBATCH --qpu=EMU_FREE
+
+source /shared/pyenv/bin/activate
+
+srun python /shared/qrmi/examples/qrmi/python/cudaq/pasqal.py

--- a/demo/qrmi/jobs/run_cudaq_pasqal.sh
+++ b/demo/qrmi/jobs/run_cudaq_pasqal.sh
@@ -8,7 +8,5 @@
 #SBATCH --qpu=EMU_FREE
 
 source /shared/pyenv/bin/activate
-source /root/.cudaq/set_env.sh
-export PYTHONPATH="/root/.cudaq${PYTHONPATH:+:${PYTHONPATH}}"
 
 srun python /shared/qrmi/examples/qrmi/python/cudaq/pasqal.py

--- a/demo/qrmi/jobs/run_cudaq_pasqal.sh
+++ b/demo/qrmi/jobs/run_cudaq_pasqal.sh
@@ -8,5 +8,7 @@
 #SBATCH --qpu=EMU_FREE
 
 source /shared/pyenv/bin/activate
+source /root/.cudaq/set_env.sh
+export PYTHONPATH="/root/.cudaq${PYTHONPATH:+:${PYTHONPATH}}"
 
 srun python /shared/qrmi/examples/qrmi/python/cudaq/pasqal.py

--- a/demo/qrmi/jobs/run_local.sh
+++ b/demo/qrmi/jobs/run_local.sh
@@ -9,4 +9,4 @@
 
 # Your script goes here
 source /shared/pyenv/bin/activate
-python /shared/qrmi/examples/pulser_backend/pasqal/send_pasqal_job_local.py
+python /shared/qrmi/examples/pulser/pasqal/send_pasqal_job_local.py

--- a/demo/qrmi/jobs/run_local_backend.sh
+++ b/demo/qrmi/jobs/run_local_backend.sh
@@ -1,9 +1,0 @@
-#!/bin/bash
-
-#SBATCH --job-name=pasqal_job
-#SBATCH --ntasks=1
-#SBATCH --cpus-per-task=1
-#SBATCH --qpu=PASQAL_LOCAL
-
-# Your script goes here
-echo "Success"

--- a/demo/qrmi/jobs/run_local_backend.sh
+++ b/demo/qrmi/jobs/run_local_backend.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+#SBATCH --job-name=pasqal_job
+#SBATCH --ntasks=1
+#SBATCH --cpus-per-task=1
+#SBATCH --qpu=PASQAL_LOCAL
+
+# Your script goes here
+echo "Success"

--- a/demo/qrmi/jobs/run_pulser_backend.sh
+++ b/demo/qrmi/jobs/run_pulser_backend.sh
@@ -7,4 +7,4 @@
 
 # Your script goes here
 source /shared/pyenv/bin/activate
-srun python /shared/qrmi/examples/pulser_backend/pulser_backend.py
+srun python /shared/qrmi/examples/pulser_backend/pasqal/pulser_backend.py

--- a/demo/qrmi/jobs/run_pulser_backend.sh
+++ b/demo/qrmi/jobs/run_pulser_backend.sh
@@ -1,10 +1,11 @@
 #!/bin/bash
 
 #SBATCH --job-name=pasqal_job
+#SBATCH --output=/data/job_%j.out
+#SBATCH --error=/data/job_%j.out
 #SBATCH --ntasks=1
 #SBATCH --cpus-per-task=1
-#SBATCH --qpu=FRESNEL
+#SBATCH --qpu=EMU_FREE
 
-# Your script goes here
 source /shared/pyenv/bin/activate
-srun python /shared/qrmi/examples/pulser_backend/pasqal/pulser_backend.py
+srun python /shared/qrmi/examples/pulser/pasqal/pulser.py

--- a/demo/qrmi/jobs/run_qpp_sampler.sh
+++ b/demo/qrmi/jobs/run_qpp_sampler.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-#SBATCH --job-name=pasqal_job
+#SBATCH --job-name=pasqal_qpp_sampler_v2
 #SBATCH --output=/data/job_%j.out
 #SBATCH --error=/data/job_%j.out
 #SBATCH --ntasks=1
@@ -8,4 +8,4 @@
 #SBATCH --qpu=EMU_FREE
 
 source /shared/pyenv/bin/activate
-srun python /shared/qrmi/examples/pulser/pasqal/pulser_qrmi.py
+srun python /shared/qrmi/examples/qiskit_primitives/pasqal/sampler.py

--- a/demo/qrmi/slurm-docker-cluster/INSTALL.md
+++ b/demo/qrmi/slurm-docker-cluster/INSTALL.md
@@ -210,7 +210,18 @@ Options provided by plugins:
 [root@login /]# sbatch /shared/spank-plugins/demo/qrmi/jobs/run_pulser_backend.sh
 ```
 
-5. Running CUDA-Q Pasqal Cloud QRMI job
+5. Running Pasqal Qiskit Provider `SamplerV2` job via QRMI
+
+```bash
+[root@login /]# sbatch /shared/spank-plugins/demo/qrmi/jobs/run_pasqal_qpp_sampler_v2.sh
+```
+
+Expected output in `/data/job_<id>.out` includes final counts, e.g.:
+```text
+{'100010': 10, '000100': 2, ...}
+```
+
+6. Running CUDA-Q Pasqal Cloud QRMI job
 
 Requires additionally installing CUDA-Q with QRMI support.
 
@@ -218,7 +229,7 @@ Requires additionally installing CUDA-Q with QRMI support.
 [root@login /]# sbatch /shared/spank-plugins/demo/qrmi/jobs/run_cudaq_pasqal.sh
 ```
 
-6. Checking primitive results
+7. Checking primitive results
 
 Once above scripts are completed, you must find `slurm-{job_id}.out` in the current directory.
 
@@ -251,8 +262,8 @@ For example,
 
 ### Running serialized jobs using the qrmi_task_runner Slurm Cluster
 
-It is possible to run JSON-serialized jobs directly using a commandline utility called qrmi_task runner.
-See [the docs](https://github.com/qiskit-community/qrmi/blob/main/bin/task_runner/README.md) for that tool for details.
+It is possible to run JSON-serialized jobs directly using a commandline utility called `qrmi_task_runner`.
+See [the docs](https://github.com/qiskit-community/qrmi/blob/main/python/qrmi/tools/task_runner/README.md) for that tool for details.
 
 ```bash
 [root@login /]# sbatch /shared/spank-plugins/demo/qrmi/jobs/run_task.sh

--- a/demo/qrmi/slurm-docker-cluster/INSTALL.md
+++ b/demo/qrmi/slurm-docker-cluster/INSTALL.md
@@ -186,15 +186,6 @@ Options provided by plugins:
 
 ### Running examples of primitive job in Slurm Cluster
 
-> [!NOTE]
-> The CUDA-Q Pasqal QRMI example below requires:
-> - CUDA-Q installed in `/shared/pyenv` with `libcudaq-pasqal-qpu.so`
-> - QRMI built at `/shared/qrmi/target/release/libqrmi.so`
-> - Pasqal cloud credentials configured (for example `/root/.pasqal/config`)
-> - `qrmi_config.json` resource name matching `--qpu=EMU_FREE`
-> - Optional per-resource override in `qrmi_config.json` `environment`:
->   `CUDAQ_QRMI_RESOURCE_TYPE=pasqal-cloud`
-
 1. Loging in to login node
 
 ```bash
@@ -220,6 +211,8 @@ Options provided by plugins:
 ```
 
 5. Running CUDA-Q Pasqal Cloud QRMI job
+
+Requires additionally installing CUDA-Q with QRMI support.
 
 ```bash
 [root@login /]# sbatch /shared/spank-plugins/demo/qrmi/jobs/run_cudaq_pasqal.sh

--- a/demo/qrmi/slurm-docker-cluster/INSTALL.md
+++ b/demo/qrmi/slurm-docker-cluster/INSTALL.md
@@ -186,6 +186,15 @@ Options provided by plugins:
 
 ### Running examples of primitive job in Slurm Cluster
 
+> [!NOTE]
+> The CUDA-Q Pasqal QRMI example below requires:
+> - CUDA-Q installed in `/shared/pyenv` with `libcudaq-pasqal-qpu.so`
+> - QRMI built at `/shared/qrmi/target/release/libqrmi.so`
+> - Pasqal cloud credentials configured (for example `/root/.pasqal/config`)
+> - `qrmi_config.json` resource name matching `--qpu=EMU_FREE`
+> - Optional per-resource override in `qrmi_config.json` `environment`:
+>   `CUDAQ_QRMI_RESOURCE_TYPE=pasqal-cloud`
+
 1. Loging in to login node
 
 ```bash
@@ -210,7 +219,13 @@ Options provided by plugins:
 [root@login /]# sbatch /shared/spank-plugins/demo/qrmi/jobs/run_pulser_backend.sh
 ```
 
-5. Checking primitive results
+5. Running CUDA-Q Pasqal Cloud QRMI job
+
+```bash
+[root@login /]# sbatch /shared/spank-plugins/demo/qrmi/jobs/run_cudaq_pasqal.sh
+```
+
+6. Checking primitive results
 
 Once above scripts are completed, you must find `slurm-{job_id}.out` in the current directory.
 

--- a/demo/qrmi/slurm-docker-cluster/INSTALL.md
+++ b/demo/qrmi/slurm-docker-cluster/INSTALL.md
@@ -213,7 +213,7 @@ Options provided by plugins:
 5. Running Pasqal Qiskit Provider `SamplerV2` job via QRMI
 
 ```bash
-[root@login /]# sbatch /shared/spank-plugins/demo/qrmi/jobs/run_pasqal_qpp_sampler_v2.sh
+[root@login /]# sbatch /shared/spank-plugins/demo/qrmi/jobs/run_qpp_sampler.sh
 ```
 
 Expected output in `/data/job_<id>.out` includes final counts, e.g.:

--- a/plugins/spank_qrmi/CMakeLists.txt
+++ b/plugins/spank_qrmi/CMakeLists.txt
@@ -112,16 +112,8 @@ add_library (spank_qrmi MODULE spank_qrmi.c buf.c strbuf.c)
 add_dependencies(spank_qrmi QRMI)
 set_target_properties (spank_qrmi PROPERTIES PREFIX "" SUFFIX "" OUTPUT_NAME "spank_qrmi.so")
 
-
-if(ENABLE_MUNGE)
-    find_library(MUNGE_LIB NAMES munge REQUIRED)
-    set(MUNGE_LINK_LIB ${MUNGE_LIB})
-else()
-    set(MUNGE_LINK_LIB "")
-endif()
-
 target_link_libraries(spank_qrmi
-    PRIVATE dl pthread m ${MUNGE_LINK_LIB} ${QRMI_SOURCE_DIR}/target/release/libqrmi.a
+    PRIVATE dl pthread m ${QRMI_SOURCE_DIR}/target/release/libqrmi.a
 )
 target_include_directories(spank_qrmi
     PRIVATE ${QRMI_SOURCE_DIR}

--- a/plugins/spank_qrmi/spank_qrmi.c
+++ b/plugins/spank_qrmi/spank_qrmi.c
@@ -57,22 +57,6 @@ static qpu_resource_t *_acquire_qpu(spank_t spank_ctxt, char *name, QrmiResource
 static void _release_qpu(qpu_resource_t *res);
 
 /*
- * @function _dump_environ
- *
- * Dumps all environment variables set for the current process.
- */
-static void _dump_environ() {
-    char **s = environ;
-    int pid = (int)getpid();
-    int uid = (int)getuid();
-
-    slurm_debug("%s(%d, %d): environment variables ---", plugin_name, pid, uid);
-    for (; *s; s++) {
-        slurm_debug("%s(%d, %d): %s", plugin_name, pid, uid, *s);
-    }
-}
-
-/*
  * @function _starts_with
  *
  * Tests if this string(`str`) starts with the specified `prefix`.
@@ -192,7 +176,7 @@ int slurm_spank_init_post_opt(spank_t spank_ctxt, int argc, char **argv) {
 
     if (g_qpu_names_opt == NULL) {
         /* noop if this is not QPU job */
-        return SLURM_ERROR;
+        return SLURM_SUCCESS;
     }
 
     /*
@@ -329,8 +313,6 @@ int slurm_spank_init_post_opt(spank_t spank_ctxt, int argc, char **argv) {
                 spank_setenv(spank_ctxt, keybuf.buffer, envvar.value, KEEP_IF_EXISTS);
             }
 
-            _dump_environ();
-
             /*
              * Acquire QPU resource.
              */
@@ -419,11 +401,15 @@ int slurm_spank_task_init(spank_t spank_ctxt, int argc, char **argv) {
 
     char *optargp = NULL;
     if (spank_option_getopt(spank_ctxt, &spank_qrmi_options[0], &optargp) != ESPANK_SUCCESS) {
-        /* if spank_qrmi plugin is not registered, simply returns an error. */
-        return SLURM_ERROR;
+        /* noop if this is not QPU job */
+        return SLURM_SUCCESS;
+    }
+    if (optargp == NULL) {
+        /* noop if this is not QPU job */
+        return SLURM_SUCCESS;
     }
     size_t optlen = strlen(optargp);
-    if ((optargp == NULL) || optlen == 0) {
+    if (optlen == 0) {
         /* noop if this is not QPU job */
         return SLURM_SUCCESS;
     }
@@ -568,6 +554,9 @@ int slurm_spank_exit(spank_t spank_ctxt, int argc, char **argv) {
  */
 static qpu_resource_t *_acquired_resource_create(char *name, QrmiResourceType type,
                                                  const char *token) {
+    if (token == NULL) {
+        return NULL;
+    }
     /*
      * use strcpy() to fix the error - ‘strncpy’ specified bound depends on the length of the
      * source argument - caused by some C compilers.


### PR DESCRIPTION
## Description of Change

This PR adds initial CUDA-Q support for Pasqal Cloud through QRMI, and updates related docs/examples.

See QRMI PR:   https://github.com/qiskit-community/qrmi/pull/55
See CUDA-Q PR: https://github.com/NVIDIA/cuda-quantum/pull/4023

No functional change, only docs.

## Checklist ✅

- [ x ] Have you included a description of this change?
- [ x ] Have you updated the relevant documentation to reflect this change?
- [ x ] Have you made sure CI is passing before requesting a review?

## Ticket
- [ ] Fixes #
- [ ] Is Part of #
