### PR TITLE
[FEAT] Option to target specific tag/branch/commit of the QRMI

### DIFF
--- a/plugins/spank_qrmi/CMakeLists.txt
+++ b/plugins/spank_qrmi/CMakeLists.txt
@@ -34,6 +34,8 @@ endif()
 #   -DQRMI_ROOT=/path/to/qrmi   Use local QRMI code.
 #   unset/empty QRMI_ROOT       Fetch QRMI via ExternalProject on GitHub (default).
 set(QRMI_ROOT "" CACHE PATH "Path to local qrmi checkout; leave empty to fetch from GitHub")
+# Option to target a specific QRMI git tag/branch/commit when fetching from GitHub
+set(QRMI_GIT_TAG "main" CACHE STRING "QRMI git tag, branch, or commit hash to fetch from GitHub")
 # Option to enable/disable Munge (required for pasqal-local usage)
 option(ENABLE_MUNGE "Enable Munge support for Pasqal Local client" OFF)
 
@@ -69,7 +71,7 @@ else()
   set(QRMI_SOURCE_DIR "${CMAKE_BINARY_DIR}/deps/src/QRMI")
   ExternalProject_Add(QRMI
     GIT_REPOSITORY https://github.com/qiskit-community/qrmi.git
-    GIT_TAG main
+    GIT_TAG ${QRMI_GIT_TAG}
     PREFIX ${CMAKE_BINARY_DIR}/deps
     CONFIGURE_COMMAND ""
     BUILD_COMMAND ${QRMI_BUILD_CMD}

--- a/plugins/spank_qrmi/README.md
+++ b/plugins/spank_qrmi/README.md
@@ -46,6 +46,13 @@ cmake -DQRMI_ROOT=/shared/qrmi ..
 make
 ```
 
+To build against a specific QRMI tag, branch, or commit hash instead of the default `main` branch:
+
+```shell-session
+cmake -DQRMI_GIT_TAG=v0.13.2 ..
+make
+```
+
 By default, the [CMakeLists.txt](./CMakeLists.txt) file expects the Slurm header file (`slurm.h`) to be located in `/usr/include/slurm`, but this can be customized as shown below.
 
 ```shell-session


### PR DESCRIPTION
## Description of Change

In this MR I add a new optional flag to target a specific tag/branch/commit of the QRMI when building the spank plugin instead of the main branch (left as default).

```shell-session
cmake -DQRMI_GIT_TAG=v0.3.0 ..
make
```

Pinning the QRMI version used during the build makes the resulting plugin binary reproducible and prevents unexpected breakage from upstream changes on `main`.

<!-- Please include a readable description about the change. -->

## Checklist ✅

- [x] Have you included a description of this change?
- [x] Have you updated the relevant documentation to reflect this change?
- [x] Have you made sure CI is passing before requesting a review?

## Ticket
- [ ] Fixes #
- [ ] Is Part of #
