### PR TITLE
Add QRMI_JOB_QPU_<TYPES,RESOURCES> env var backwards compatible

### DIFF
--- a/docs/ux.md
+++ b/docs/ux.md
@@ -87,7 +87,7 @@ srun ...
 
 HPC applications use the Slurm QPU resources assigned to the Slurm job.
 
-Environment variables provide more details for use by the appliction, e.g. `SLURM_JOB_QPU_RESOURCES` listing the quantum resource names (comma separated if there are several provided).
+Environment variables provide more details for use by the appliction, e.g. `QRMI_JOB_QPU_RESOURCES` listing the quantum resource names (comma separated if there are several provided). `SLURM_JOB_QPU_RESOURCES` is still exported as a legacy alias.
 These variables will be used by QRMI.
 See the README files in the various QRMI flavor directories ([ibm](https://github.com/qiskit-community/qrmi/blob/main/examples/qiskit_primitives/ibm/README.md), [pasqal](https://github.com/qiskit-community/qrmi/blob/main/examples/qiskit_primitives/pasqal/README.md)) for details.
 

--- a/plugins/spank_qrmi/README.md
+++ b/plugins/spank_qrmi/README.md
@@ -208,8 +208,10 @@ This plugin also set the following 2 environment variables which will be referre
 
 | environment varilables | descriptions |
 | ---- | ---- |
-| SLURM_JOB_QPU_RESOURCES | Comma separated list of QPU resources to use at runtime. Undocumented resources will be filtered out. For example, `qpu1,qpu2`. |
-| SLURM_JOB_QPU_TYPES | Comma separated list of Resource type (`ibm-quantum-system`, `qiskit-runtime-service` and `pasqal-cloud`). For example, `ibm-quantum-system,ibm-quantum-system` |
+| QRMI_JOB_QPU_RESOURCES | Comma separated list of QPU resources to use at runtime. Undocumented resources will be filtered out. For example, `qpu1,qpu2`. |
+| QRMI_JOB_QPU_TYPES | Comma separated list of Resource type (`ibm-quantum-system`, `qiskit-runtime-service` and `pasqal-cloud`). For example, `ibm-quantum-system,ibm-quantum-system` |
+| SLURM_JOB_QPU_RESOURCES | Legacy alias for `QRMI_JOB_QPU_RESOURCES`. |
+| SLURM_JOB_QPU_TYPES | Legacy alias for `QRMI_JOB_QPU_TYPES`. |
 
 > [!IMPORTANT]
 > The IBM Direct Access API has been renamed to the IBM Quantum System API.

--- a/plugins/spank_qrmi/spank_qrmi.c
+++ b/plugins/spank_qrmi/spank_qrmi.c
@@ -218,6 +218,8 @@ int slurm_spank_init_post_opt(spank_t spank_ctxt, int argc, char **argv) {
     spank_setenv(spank_ctxt, "QRMI_JOB_ID", id_str, OVERWRITE);
     setenv("QRMI_JOB_ID", id_str, 1);
 
+    spank_setenv(spank_ctxt, "QRMI_JOB_QPU_RESOURCES", "", OVERWRITE);
+    spank_setenv(spank_ctxt, "QRMI_JOB_QPU_TYPES", "", OVERWRITE);
     spank_setenv(spank_ctxt, "SLURM_JOB_QPU_RESOURCES", "", OVERWRITE);
     spank_setenv(spank_ctxt, "SLURM_JOB_QPU_TYPES", "", OVERWRITE);
 
@@ -383,6 +385,11 @@ int slurm_spank_init_post_opt(spank_t spank_ctxt, int argc, char **argv) {
     }
     slurm_list_iterator_destroy(sessions_iter);
 
+    spank_setenv(spank_ctxt, "QRMI_JOB_QPU_RESOURCES", qpu_resources_envvar.buffer, OVERWRITE);
+    slurm_debug("%s: setenv(%s, %s)", plugin_name, "QRMI_JOB_QPU_RESOURCES",
+                qpu_resources_envvar.buffer);
+    spank_setenv(spank_ctxt, "QRMI_JOB_QPU_TYPES", qpu_types_envvar.buffer, OVERWRITE);
+    slurm_debug("%s: setenv(%s, %s)", plugin_name, "QRMI_JOB_QPU_TYPES", qpu_types_envvar.buffer);
     spank_setenv(spank_ctxt, "SLURM_JOB_QPU_RESOURCES", qpu_resources_envvar.buffer, OVERWRITE);
     slurm_debug("%s: setenv(%s, %s)", plugin_name, "SLURM_JOB_QPU_RESOURCES",
                 qpu_resources_envvar.buffer);


### PR DESCRIPTION
## Description of Change

Addressing
https://github.com/qiskit-community/qrmi/issues/123

Compared to @ohtanim 's original I favoured keeping `JOB` in the env var. Happy to revise that if there are strong opinions. but the reasoning is simply to keep the job resources separately from the defined ones.
https://github.com/qiskit-community/qrmi/pull/119/changes/40075374047803244771e98a1ea3c8686e3326a1

I've tested this with Pasqal local and cloud. 

From @yoonho's description:

We want QRMI to be resource manager agnostic. This means no mention of specific resource managers in the QRMI code or only when it is absolutely necessary. [primitives/service.py](https://github.com/qiskit-community/qrmi/blob/main/python/qrmi/primitives/service.py) looks for SLURM_JOB_QPU_RESOURCES and SLURM_JOB_QPU_TYPES.

So we:

Change SLURM_JOB_QPU_RESOURCES and SLURM_JOB_QPU_TYPES to QRMI_JOB_QPU_RESOURCES and QRMI_JOB_QPU_TYPES

## Checklist ✅

- [x ] Have you included a description of this change?
- [ x] Have you updated the relevant documentation to reflect this change?
- [x ] Have you made sure CI is passing before requesting a review?

## Ticket
- [ ] Fixes #
- [ ] Is Part of #
