### PR TITLE
[PASQAL] Rename url env var

### DIFF
--- a/demo/qrmi/etc/slurm/qrmi_config.json
+++ b/demo/qrmi/etc/slurm/qrmi_config.json
@@ -37,7 +37,7 @@
       "name": "PASQAL_LOCAL",
       "type": "pasqal-local",
       "environment": {
-        "QRMI_URL": "http://localhost:4207"
+        "QRMI_WARDEN_URL": "http://localhost:8006"
       }
     },
     {


### PR DESCRIPTION
## Description of Change

Following the rename in https://github.com/qiskit-community/qrmi/pull/157 , rename the env var `QRMI_URL` to `QRMI_WARDEN_URL`.

Also change the port to default `8006`.

## Checklist ✅

- [x] Have you included a description of this change?
- [x] Have you updated the relevant documentation to reflect this change?
- [x] Have you made sure CI is passing before requesting a review?
