### PR TITLE
Add support of slurm-26.05

### DIFF
--- a/plugins/spank_qrmi/spank_qrmi.c
+++ b/plugins/spank_qrmi/spank_qrmi.c
@@ -557,7 +557,13 @@ int slurm_spank_task_init(spank_t spank_ctxt, int argc, char **argv) {
 
     char limit_as_str[MAX_INT_STRLEN + 1] = {0}; /* max uint32_t value is (2147483647) = 10 chars */
     if (spank_get_item(spank_ctxt, S_JOB_ID, &job_id) == ESPANK_SUCCESS) {
+#if SLURM_VERSION_NUMBER >= SLURM_VERSION_NUM(26, 5, 0)
+        slurm_step_id_t step_id = SLURM_STEP_ID_INITIALIZER;
+        step_id.job_id = job_id;
+        if (slurm_load_job(&job_info_msg, step_id, SHOW_DETAIL) == SLURM_SUCCESS) {
+#else
         if (slurm_load_job(&job_info_msg, job_id, SHOW_DETAIL) == SLURM_SUCCESS) {
+#endif
             /*
              * Slurm's time limit is represented in minutes
              */


### PR DESCRIPTION
## Description of Change

<!-- Please include a readable description about the change. -->
Added support for Slurm v26.05. The Slurm library(`libslurm.so`) interface changed as of v26.05, so our spank plugin currently fails to build with the following error. This PR introduces conditional compilation referring to `SLURM_VERSION_NUMBER` to support both v26.05 and older versions.

```
/shared/spank-plugins/plugins/spank_qrmi/spank_qrmi.c:560:43: error: incompatible type for argument 2 of ‘slurm_load_job’
  560 |         if (slurm_load_job(&job_info_msg, job_id, SHOW_DETAIL) == SLURM_SUCCESS) {
      |                                           ^~~~~~
      |                                           |
      |                                           uint32_t {aka unsigned int}
In file included from /shared/spank-plugins/plugins/spank_qrmi/spank_qrmi.c:26:
/usr/include/slurm/slurm.h:4256:66: note: expected ‘slurm_step_id_t’ but argument is of type ‘uint32_t’ {aka ‘unsigned int’}
 4256 | extern int slurm_load_job(job_info_msg_t **resp, slurm_step_id_t step_id,
      |                                                  ~~~~~~~~~~~~~~~~^~~~~~~
```

## Checklist ✅

- [x] Have you included a description of this change?
- [ ] Have you updated the relevant documentation to reflect this change?
- [ ] Have you made sure CI is passing before requesting a review?

## Ticket
- [ ] Fixes #
- [ ] Is Part of #
