### PR TITLE
Install QRMI along with quantum resource dependencies

### DIFF
--- a/demo/qrmi/slurm-docker-cluster/INSTALL.md
+++ b/demo/qrmi/slurm-docker-cluster/INSTALL.md
@@ -111,14 +111,14 @@ source /shared/pyenv/bin/activate
 pip install --upgrade pip
 ```
 
-3. Building and installing [QRMI](https://github.com/qiskit-community/qrmi/blob/main/INSTALL.md) **on c1**
+3. Building and installing [QRMI](https://github.com/qiskit-community/qrmi/blob/main/INSTALL.md) **on c1**. Replace `NAME` by the quantum resource name(s) as described [here](https://github.com/qiskit-community/qrmi#python)
 
 ```bash
 source ~/.cargo/env
 cd /shared/qrmi
 pip install -r requirements-dev.txt
 maturin build --release
-pip install /shared/qrmi/target/wheels/qrmi-*.whl
+pip install --no-index --find-link=/shared/qrmi/target/wheels/ "qrmi[NAME]"
 ```
 
 4. Building the [SPANK plugin](../../../plugins/spank_qrmi/README.md) **on c1**


### PR DESCRIPTION
## Description of Change

The qrmi wheel must be installed along with the dependencies for the quantum  resource name(s) that will be used, otherwise, required packages such as qiskit_ibm_runtime will be missing in the python venv.

## Checklist ✅

- [x] Have you included a description of this change?
- [x] Have you updated the relevant documentation to reflect this change?
- [ ] Have you made sure CI is passing before requesting a review?

## Ticket
- [ ] Fixes #
- [ ] Is Part of #
