### PR TITLE
Rebrand Qiskit Runtime Service

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,25 @@
 Quantum spank plugins for Slurm
 ===============================
 
+> [!IMPORTANT]
+> **New Deprecations(Since 0.10.0)**
+>
+> The **IBM Qiskit Runtime Service API** has been renamed to the **IBM Quantum Compute Service API**.
+> 
+> As part of this change, **the resource names and the prefixes of environment variables** used by QRMI have been updated accordingly.
+>
+> | Items | Deprecated names | New names |
+> | :--- | :--- | :--- |
+> | Resource type text | qiskit-runtime-service | ibm-quantum-compute-service |
+> | Resource type(C) | QRMI_RESOURCE_TYPE_QISKIT_RUNTIME_SERVICE | QRMI_RESOURCE_TYPE_IBM_QUANTUM_COMPUTE_SERVICE |
+> | Resource type(Python) | ResourceType.IBMQiskitRuntimeService | ResourceType.IBMQuantumComputeService |
+> | Resource type(Rust) | ResourceType::QiskitRuntimeService | ResourceType::IBMQuantumComputeService |
+> | QuantumResource trait implementator(Rust) | qrmi::ibm::IBMQiskitRuntimeService | qrmi::ibm::IBMQuantumComputeService |
+> | Environment variable prefixes | QRMI_IBM_QRS_ | QRMI_IBM_QCS_ |
+> 
+> A transition period will be in effect until **October 21, 2026**. During this period, both the legacy and the new resource names and environment variable prefixes are supported to ensure backward compatibility. After the transition period ends, support for the legacy names will be removed, and users are expected to migrate fully to the new naming scheme.
+
+
 This is repository with Slurm Spank plugins for Quantum resources and jobs support.
 
 ### Table of Contents

--- a/demo/qrmi/etc/slurm/qrmi_config.json
+++ b/demo/qrmi/etc/slurm/qrmi_config.json
@@ -17,12 +17,12 @@
     },
     {
       "name": "ibm_sherbrooke",
-      "type": "qiskit-runtime-service",
+      "type": "ibm-quantum-compute-service",
       "environment": {
-        "QRMI_IBM_QRS_ENDPOINT": "https://quantum.cloud.ibm.com/api/v1",
-        "QRMI_IBM_QRS_IAM_ENDPOINT": "https://iam.cloud.ibm.com",
-        "QRMI_IBM_QRS_IAM_APIKEY": "<YOUR IAM APIKEY FOR THIS BACKEND>",
-        "QRMI_IBM_QRS_SERVICE_CRN": "<YOUR IQP INSTANCE CRN>"
+        "QRMI_IBM_QCS_ENDPOINT": "https://quantum.cloud.ibm.com/api/v1",
+        "QRMI_IBM_QCS_IAM_ENDPOINT": "https://iam.cloud.ibm.com",
+        "QRMI_IBM_QCS_IAM_APIKEY": "<YOUR IAM APIKEY FOR THIS BACKEND>",
+        "QRMI_IBM_QCS_SERVICE_CRN": "<YOUR IQP INSTANCE CRN>"
       }
     },
     {

--- a/demo/qrmi/slurm-docker-cluster/file.patch
+++ b/demo/qrmi/slurm-docker-cluster/file.patch
@@ -365,12 +365,12 @@ diff -Naru slurm-docker-cluster.orig/qrmi_config.json slurm-docker-cluster/qrmi_
 +    },
 +    {
 +      "name": "alt_marrakesh",
-+      "type": "qiskit-runtime-service",
++      "type": "ibm-quantum-compute-service",
 +      "environment": {
-+        "QRMI_IBM_QRS_ENDPOINT": "https://quantum.cloud.ibm.com/api/v1",
-+        "QRMI_IBM_QRS_IAM_ENDPOINT": "https://iam.cloud.ibm.com",
-+        "QRMI_IBM_QRS_IAM_APIKEY": "<YOUR IAM APIKEY FOR THIS BACKEND>",
-+        "QRMI_IBM_QRS_SERVICE_CRN": "<YOUR IQP INSTANCE CRN>"
++        "QRMI_IBM_QCS_ENDPOINT": "https://quantum.cloud.ibm.com/api/v1",
++        "QRMI_IBM_QCS_IAM_ENDPOINT": "https://iam.cloud.ibm.com",
++        "QRMI_IBM_QCS_IAM_APIKEY": "<YOUR IAM APIKEY FOR THIS BACKEND>",
++        "QRMI_IBM_QCS_SERVICE_CRN": "<YOUR IQP INSTANCE CRN>"
 +      }
 +    },
 +    {
@@ -421,12 +421,12 @@ diff -Naru slurm-docker-cluster.orig/qrmi_config.json.example slurm-docker-clust
 +    },
 +    {
 +      "name": "alt_marrakesh",
-+      "type": "qiskit-runtime-service",
++      "type": "ibm-quantum-compute-service",
 +      "environment": {
-+        "QRMI_IBM_QRS_ENDPOINT": "https://quantum.cloud.ibm.com/api/v1",
-+        "QRMI_IBM_QRS_IAM_ENDPOINT": "https://iam.cloud.ibm.com",
-+        "QRMI_IBM_QRS_IAM_APIKEY": "<YOUR IAM APIKEY FOR THIS BACKEND>",
-+        "QRMI_IBM_QRS_SERVICE_CRN": "<YOUR IQP INSTANCE CRN>",
++        "QRMI_IBM_QCS_ENDPOINT": "https://quantum.cloud.ibm.com/api/v1",
++        "QRMI_IBM_QCS_IAM_ENDPOINT": "https://iam.cloud.ibm.com",
++        "QRMI_IBM_QCS_IAM_APIKEY": "<YOUR IAM APIKEY FOR THIS BACKEND>",
++        "QRMI_IBM_QCS_SERVICE_CRN": "<YOUR IQP INSTANCE CRN>",
 +      }
 +    },
 +    {

--- a/docs/ux.md
+++ b/docs/ux.md
@@ -10,7 +10,7 @@ HPC user experience, HPC developer experience and usage patterns
   - [HPC application scope](#hpc-application-scope)
   - [Backend specifics](#backend-specifics)
     - [IBM Quantum System API](#ibm-quantum-system-api)
-    - [Qiskit Runtime Service](#qiskit-runtime-service)
+    - [IBM Quantum Compute(formerly Qiskit Runtime) Service](#ibm-quantum-compute-service)
     - [IQM Server API](#iqm-server-api)
     - [Pasqal](#pasqal)
     - [Alice and Bob Felis API](#alice-and-bob-felis-api)
@@ -28,8 +28,8 @@ Slurm QPU resource definitions determine what physical resources can be used by 
 User source code should be agnostic to specific backend instances and even backend types as far as possible.
 This keeps source code portable while the QPU selection criteria are part of the resource definition (which is considered configuration as opposed to source code).
 The source code does not have to take care resp. is not involved in resource reservation handling (that is done when Slurm jobs are assigned QPU resources and start running, if applicable on the backend) or execution modes like sessions (these are automatically in place while the job is running, if applicable on the backend).
-This makes the source code more portable between similar QPU resource types through different backend access methods (such as IBM's Quantum System API and IBM's Qiskit Runtime service through IBM Quantum Platform).
-All backend types (such as IBM's Quantum System API, IBM's Qiskit Runtime service, IQM Server API, or Pasqal's backends) follow these principles.
+This makes the source code more portable between similar QPU resource types through different backend access methods (such as IBM Quantum System API and IBM Quantum Compute Service through IBM Quantum Platform).
+All backend types (such as IBM Quantum System API, IBM Quantum Compute Service, IQM Server API, or Pasqal's backends) follow these principles.
 
 ## Connecting physical resources to Slurm resources and how to use them
 
@@ -161,18 +161,18 @@ Instead, mid term, there can be two different modes that HPC users can specify:
 * `exclusive=true` specifies that no other jobs can use the resource at the same time. An exclusive mode job gets all execution lanes and can not run at the same time as a non-exclusive job
 * `exclusive=false` allows other jobs to run in parallel. In that case, there can be as many jobs as there are execution lanes at the same time, and the job essentially only gets one lane
 
-#### Qiskit Runtime Service
+#### IBM Quantum Compute(formerly Qiskit Runtime) Service
 ##### HPC user scope
 
 It is expected, that users specify additional access details in environment variables.
 Specifically, this includes
 
-* Qiskit Runtime service instance (CRN, Cloud Resource Name)
-* Endpoint for Qiskit Runtime (unless auto-detected from the CRN)
+* IBM Quantum Compute Service instance (CRN, Cloud Resource Name)
+* Endpoint for IBM Quantum Compute Service (unless auto-detected from the CRN)
 * API key which has access to the CRN
 * S3 instance, bucket and access token/credentials for data transfers
 
-This determines under which user and service instance the Qiskit Runtime service is used
+This determines under which user and service instance the IBM Quantum Compute Service is used
 Accordingly, IBM Quantum Platform's scheduling considers the user's and service instance's capabilities for scheduling.
 
 At this time, users have to provide the above details (no shared cluster-wide Quantum access).

--- a/plugins/spank_qrmi/README.md
+++ b/plugins/spank_qrmi/README.md
@@ -75,7 +75,7 @@ The `resources` array contains a set of available Quantum Resources which can be
 | properties | descriptions |
 | ---- | ---- |
 | name | Quantum resource name. e.g. Quantum backend name. |
-| type | Resource type (`ibm-quantum-system`, `qiskit-runtime-service` and `pasqal-cloud`) |
+| type | Resource type (`ibm-quantum-system`, `ibm-quantum-compute-service`, `qiskit-runtime-service`(deprecated) and `pasqal-cloud`) |
 | environment | A set of environment variables to work with QRMI. Current implementations assume API endpoint and credentials are specified via environment variable setting. |
 
 If a user specifies a resource with the --qpu option that is not defined in the qrmi_config.json file, the specification will be ignored.
@@ -84,7 +84,11 @@ If the user sets the necessary environment variables for job execution themselve
 
 
 > [!NOTE]
-> If you are using a QPU resource with the resource type `qiskit-runtime-service`, use an account that supports [opening a session](https://quantum.cloud.ibm.com/docs/en/guides/run-jobs-session#open-a-session), such as a Premium plan.
+> If you are using a QPU resource with the resource type `ibm-quantum-compute-service`, use an account that supports [opening a session](https://quantum.cloud.ibm.com/docs/en/guides/run-jobs-session#open-a-session), such as a Premium plan.
+> If you are using an account that does not support opening a session, such as an Open plan account, add `QRMI_IBM_QCS_SESSION_MODE="batch"` to the environment variable list in qrmi_config.json as workaround:
+
+> [!NOTE]
+> If you are using a QPU resource with the resource type `qiskit-runtime-service`(deprecated), use an account that supports [opening a session](https://quantum.cloud.ibm.com/docs/en/guides/run-jobs-session#open-a-session), such as a Premium plan.
 > If you are using an account that does not support opening a session, such as an Open plan account, add `QRMI_IBM_QRS_SESSION_MODE="batch"` to the environment variable list in qrmi_config.json as workaround:
 
 ## Installation
@@ -228,7 +232,7 @@ This plugin also set the following 2 environment variables which will be referre
 | environment varilables | descriptions |
 | ---- | ---- |
 | QRMI_JOB_QPU_RESOURCES | Comma separated list of QPU resources to use at runtime. Undocumented resources will be filtered out. For example, `qpu1,qpu2`. |
-| QRMI_JOB_QPU_TYPES | Comma separated list of Resource type (`ibm-quantum-system`, `qiskit-runtime-service` and `pasqal-cloud`). For example, `ibm-quantum-system,ibm-quantum-system` |
+| QRMI_JOB_QPU_TYPES | Comma separated list of Resource type (`ibm-quantum-system`, `ibm-quantum-compute-service`, `qiskit-runtime-service`(deprecated) and `pasqal-cloud`). For example, `ibm-quantum-system,ibm-quantum-system` |
 | SLURM_JOB_QPU_RESOURCES | Legacy alias for `QRMI_JOB_QPU_RESOURCES`. |
 | SLURM_JOB_QPU_TYPES | Legacy alias for `QRMI_JOB_QPU_TYPES`. |
 

--- a/plugins/spank_qrmi/qrmi_config.json.example
+++ b/plugins/spank_qrmi/qrmi_config.json.example
@@ -32,12 +32,12 @@
     },
     {
       "name": "alt_marrakesh",
-      "type": "qiskit-runtime-service",
+      "type": "ibm-quantum-compute-service",
       "environment": {
-        "QRMI_IBM_QRS_ENDPOINT": "https://quantum.cloud.ibm.com/api/v1",
-        "QRMI_IBM_QRS_IAM_ENDPOINT": "https://iam.cloud.ibm.com",
-        "QRMI_IBM_QRS_IAM_APIKEY": "<YOUR IAM APIKEY FOR THIS BACKEND>",
-        "QRMI_IBM_QRS_SERVICE_CRN": "<YOUR IQP INSTANCE CRN>"
+        "QRMI_IBM_QCS_ENDPOINT": "https://quantum.cloud.ibm.com/api/v1",
+        "QRMI_IBM_QCS_IAM_ENDPOINT": "https://iam.cloud.ibm.com",
+        "QRMI_IBM_QCS_IAM_APIKEY": "<YOUR IAM APIKEY FOR THIS BACKEND>",
+        "QRMI_IBM_QCS_SERVICE_CRN": "<YOUR IQP INSTANCE CRN>"
       }
     },
     {


### PR DESCRIPTION
## Description of Change

<!-- Please include a readable description about the change. -->
This PR will follow [the changes](https://github.com/qiskit-community/qrmi/pull/199) being prepared in QRMI side.

> [!IMPORTANT]
> **New Deprecations(Since 0.10.0)**
>
> The **IBM Qiskit Runtime Service API** has been renamed to the **IBM Quantum Compute Service API**.
>
> As part of this change, **the resource names and the prefixes of environment variables** used by QRMI have been updated accordingly.
>
> | Items | Deprecated names | New names |
> | :--- | :--- | :--- |
> | Resource type text | qiskit-runtime-service | ibm-quantum-compute-service |
> | Resource type(C) | QRMI_RESOURCE_TYPE_QISKIT_RUNTIME_SERVICE | QRMI_RESOURCE_TYPE_IBM_QUANTUM_COMPUTE_SERVICE |
> | Resource type(Python) | ResourceType.IBMQiskitRuntimeService | ResourceType.IBMQuantumComputeService |
> | Resource type(Rust) | ResourceType::QiskitRuntimeService | ResourceType::IBMQuantumComputeService |
> | QuantumResource trait implementator(Rust) | qrmi::ibm::IBMQiskitRuntimeService | qrmi::ibm::IBMQuantumComputeService |
> | Environment variable prefixes | QRMI_IBM_QRS_ | QRMI_IBM_QCS_ |
>
> A transition period will be in effect until **November 21, 2026**. During this period, both the legacy and the new resource names and environment variable prefixes are supported to ensure backward compatibility. After the transition period ends, support for the legacy names will be removed, and users are expected to migrate fully to the new naming scheme.

## Checklist ✅

- [x] Have you included a description of this change?
- [x] Have you updated the relevant documentation to reflect this change?
- [x] Have you made sure CI is passing before requesting a review?

## Ticket
- [ ] Fixes #
- [ ] Is Part of #
